### PR TITLE
Add more Diagnostic Info to Home Assistant via MQTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+  
+## [1.5.1] - 2026-01-03
+### Added
+- Expanded MQTT information: added a new `base_topic/info` topic containing addon version, hardware firmware, startup time, uptime, and serial port.
+- Added MQTT Auto-Discovery for the new info sensor, appearing as a diagnostic entity in Home Assistant.
+- Enhanced error reporting: converted several non-fatal logger errors (invalid dates, parsing issues, TLS fallback) to use the MQTT error topic.
 
 ## [1.5.0] - 2026-01-03
 ### Added

--- a/DOCS.md
+++ b/DOCS.md
@@ -9,7 +9,11 @@ When the add-on starts, it automatically creates a device named **S0PCM Reader**
 - **Today**: Count for the current day.
 - **Yesterday**: Count for the previous day.
 - **Status**: A binary sensor showing if the reader is connected to MQTT.
-- **Error**: A diagnostic sensor that displays the last error encountered (e.g., serial connection failure, invalid MQTT command). This sensor clears automatically when a valid packet is received.
+- **Error**: A diagnostic sensor that displays the last error encountered.
+- **Addon Version**: Current version of the S0PCM Reader addon.
+- **S0PCM Firmware**: Firmware version reported by the hardware.
+- **Startup Time**: Timestamp of when the addon started.
+- **Serial Port**: The configured USB/serial port.
 
 **Naming:**
 The entity names are derived from the `name` field in your `measurement.yaml`. If you haven't configured a name, it defaults to the input number (e.g., "1 Total").
@@ -95,9 +99,13 @@ The following MQTT messages are sent:
 ```
 <base_topic>/1/total
 <base_topic>/1/today
-<base_topic>/1/yesterday
-...
 <base_topic>/X/total
+<base_topic>/status
+<base_topic>/error
+<base_topic>/version
+<base_topic>/firmware
+<base_topic>/startup_time
+<base_topic>/port
 ```
 
 If `mqtt_split_topic` is set to `false`, the data is sent as a JSON string:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This add-on is based on the [docker-s0pcm-reader](https://github.com/ualex73/doc
 - **Watchdog / Auto-restart**: Built on S6-overlay for robust process supervision and automatic recovery.
 - **Remote Configuration**: Update meter totals directly via MQTT topics or Home Assistant actions.
 - **Real-time Error Reporting**: Dedicated MQTT topic and diagnostic sensor for instant feedback on serial or configuration issues.
+- **Diagnostic Metadata**: New `info` topic and sensor providing versioning, hardware firmware, and uptime details.
 - **Flexible MQTT**: Supports external brokers, authentication, and custom base topics.
 
 ## 🛠️ Prerequisites

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader based on docker-s0pcm-reader"
-version: "1.5.0"
+version: "1.5.1"
 slug: "s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"
 arch:


### PR DESCRIPTION
### Added
- Expanded MQTT information: added a new `base_topic/info` topic containing addon version, hardware firmware, startup time, uptime, and serial port.
- Added MQTT Auto-Discovery for the new info sensor, appearing as a diagnostic entity in Home Assistant.
- Enhanced error reporting: converted several non-fatal logger errors (invalid dates, parsing issues, TLS fallback) to use the MQTT error topic.