### PR TITLE
Release v4.3.1-b21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
+- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: This requires a minimum Home Assistant version of 2025.5.0.
 
 ### Security
 - **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ init: false
 startup: application
 hassio_api: true
 homeassistant_api: true
+homeassistant: "2025.5.0"
 options:
   device: null
   mqtt:

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 GLOBAL_DIAGNOSTICS: Final = [
     {"id": "version", "name": "App Version", "icon": "mdi:information-outline"},
     {"id": "firmware", "name": "S0PCM Firmware", "icon": "mdi:chip"},
-    # TODO: Change to "uptime" device class once HA 2026.6 is the minimum supported version
-    {"id": "startup_time", "name": "Startup Time", "icon": "mdi:clock-outline", "class": "timestamp"},
+    {"id": "startup_time", "name": "Startup Time", "icon": "mdi:clock-start", "class": "uptime"},
     {"id": "port", "name": "Serial Port", "icon": "mdi:serial-port"},
 ]
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -40,8 +40,8 @@ def test_send_global_discovery(mocker):
     ]
     assert startup_call
     startup_payload = json.loads(startup_call[0][0][1])
-    assert startup_payload["device_class"] == "timestamp"
-    assert startup_payload["icon"] == "mdi:clock-outline"
+    assert startup_payload["device_class"] == "uptime"
+    assert startup_payload["icon"] == "mdi:clock-start"
 
 
 def test_send_meter_discovery(mocker):


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.1-b21.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates.
- **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: This requires a minimum Home Assistant version of 2025.5.0.

### Security
- **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.
```
