### PR TITLE
Release v4.3.1-b22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
-- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: This requires a minimum Home Assistant version of 2025.5.0.
+- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: Full support for the uptime device class requires Home Assistant 2025.5 or newer.
 
 ### Security
 - **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An easy-to-use Home Assistant App that reads pulse counters from an **S0PCM-2** 
 
 - An **S0PCM reader** (S0PCM-2 or S0PCM-5) connected via USB.
 - An **MQTT Broker** (e.g., the official Mosquitto broker app).
+- **Home Assistant 2025.5** or newer is recommended for full diagnostic sensor support.
 
 ## 🚀 Installation (Recommended & Supported method)
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ init: false
 startup: application
 hassio_api: true
 homeassistant_api: true
-homeassistant: "2025.5.0"
 options:
   device: null
   mqtt:


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.1-b22.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates.
- **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: Full support for the uptime device class requires Home Assistant 2025.5 or newer.

### Security
- **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.
```
