### PR TITLE
Release v4.3.1-b23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
-- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. **Note**: Full support for the uptime device class requires Home Assistant 2025.5 or newer.
+- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!
 
 ### Security
 - **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ An easy-to-use Home Assistant App that reads pulse counters from an **S0PCM-2** 
 
 - An **S0PCM reader** (S0PCM-2 or S0PCM-5) connected via USB.
 - An **MQTT Broker** (e.g., the official Mosquitto broker app).
-- **Home Assistant 2025.5** or newer is recommended for full diagnostic sensor support.
 
 ## 🚀 Installation (Recommended & Supported method)
 

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -11,13 +11,14 @@ from typing import Final
 import paho.mqtt.client as mqtt
 
 from state import AppContext, MeterState
+import utils
 
 logger = logging.getLogger(__name__)
 
 GLOBAL_DIAGNOSTICS: Final = [
     {"id": "version", "name": "App Version", "icon": "mdi:information-outline"},
     {"id": "firmware", "name": "S0PCM Firmware", "icon": "mdi:chip"},
-    {"id": "startup_time", "name": "Startup Time", "icon": "mdi:clock-start", "class": "uptime"},
+    {"id": "startup_time", "name": "Startup Time"},
     {"id": "port", "name": "Serial Port", "icon": "mdi:serial-port"},
 ]
 
@@ -80,24 +81,37 @@ def send_global_discovery(mqttc: mqtt.Client, context: AppContext) -> None:
     }
     mqttc.publish(error_topic, json.dumps(error_payload), retain=True)
 
+    ha_version = utils.get_ha_core_version()
+    ha_version_tuple = utils.parse_ha_version(ha_version)
+
     # Diagnostics
     for diag in GLOBAL_DIAGNOSTICS:
         diag_unique_id = f"s0pcm_{base_topic}_{diag['id']}"
         diag_topic = f"{discovery_prefix}/sensor/{base_topic}/{diag_unique_id}/config"
+
+        diag_data = dict(diag)
+        if diag_data["id"] == "startup_time":
+            if ha_version_tuple >= (2025, 5, 0):
+                diag_data["class"] = "uptime"
+                diag_data["icon"] = "mdi:clock-start"
+            else:
+                diag_data["class"] = "timestamp"
+                diag_data["icon"] = "mdi:clock-outline"
+
         diag_payload = {
-            "name": f"S0PCM Reader {diag['name']}",
+            "name": f"S0PCM Reader {diag_data['name']}",
             "unique_id": diag_unique_id,
             "device": device_info,
             "entity_category": "diagnostic",
-            "state_topic": base_topic + "/" + diag["id"],
+            "state_topic": base_topic + "/" + diag_data["id"],
             "value_template": "{{ value }}",
             "force_update": True,
-            "icon": diag["icon"],
+            "icon": diag_data["icon"],
         }
-        if "unit" in diag:
-            diag_payload["unit_of_measurement"] = diag["unit"]
-        if "class" in diag:
-            diag_payload["device_class"] = diag["class"]
+        if "unit" in diag_data:
+            diag_payload["unit_of_measurement"] = diag_data["unit"]
+        if "class" in diag_data:
+            diag_payload["device_class"] = diag_data["class"]
         mqttc.publish(diag_topic, json.dumps(diag_payload), retain=True)
 
     logger.info("Sent global MQTT discovery messages")

--- a/rootfs/usr/src/utils.py
+++ b/rootfs/usr/src/utils.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 from typing import Any
 import urllib.error
 import urllib.parse
@@ -149,3 +150,38 @@ def parse_localized_number(value_str: str) -> float | None:
         return float(clean_state)
     except ValueError, TypeError:
         return None
+
+
+def get_ha_core_version() -> str | None:
+    """Fetch the Home Assistant Core version from the Supervisor API."""
+    token = os.getenv("SUPERVISOR_TOKEN")
+    if not token:
+        return None
+
+    url = "http://supervisor/core/info"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=5) as response:
+            if response.status == 200:
+                data = json.loads(response.read().decode())
+                return data.get("data", {}).get("version")
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
+        logger.debug(f"Supervisor API /core/info failed: {e}")
+    return None
+
+
+def parse_ha_version(version_str: str | None) -> tuple[int, ...]:
+    """Parse a Home Assistant version string into a comparable tuple."""
+    if not version_str:
+        return (0, 0, 0)
+
+    parts = version_str.split(".")
+    parsed_parts = []
+    for p in parts:
+        match = re.match(r"^(\d+)", p)
+        if match:
+            parsed_parts.append(int(match.group(1)))
+        else:
+            parsed_parts.append(0)
+    return tuple(parsed_parts)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -11,14 +11,16 @@ import state as state_module
 from state import MeterState
 
 
-def test_send_global_discovery(mocker):
-    """Test global discovery message publishing."""
+def test_send_global_discovery_new_ha(mocker):
+    """Test global discovery message publishing with HA >= 2025.5.0."""
     import discovery
 
     mock_mqttc = MagicMock()
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
+
+    mocker.patch("utils.get_ha_core_version", return_value="2025.5.0")
 
     discovery.send_global_discovery(mock_mqttc, context)
 
@@ -42,6 +44,29 @@ def test_send_global_discovery(mocker):
     startup_payload = json.loads(startup_call[0][0][1])
     assert startup_payload["device_class"] == "uptime"
     assert startup_payload["icon"] == "mdi:clock-start"
+
+
+def test_send_global_discovery_old_ha(mocker):
+    """Test global discovery message publishing with HA < 2025.5.0."""
+    import discovery
+
+    mock_mqttc = MagicMock()
+    context = state_module.get_context()
+    context.config = make_test_config(base_topic="s0pcm")
+    context.s0pcm_reader_version = "3.0.0"
+
+    mocker.patch("utils.get_ha_core_version", return_value="2024.12.0")
+
+    discovery.send_global_discovery(mock_mqttc, context)
+
+    # Check startup_time sensor fallback
+    startup_call = [
+        c for c in mock_mqttc.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_startup_time/config" in str(c)
+    ]
+    assert startup_call
+    startup_payload = json.loads(startup_call[0][0][1])
+    assert startup_payload["device_class"] == "timestamp"
+    assert startup_payload["icon"] == "mdi:clock-outline"
 
 
 def test_send_meter_discovery(mocker):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,6 +108,46 @@ def test_get_supervisor_config_api_error(mocker):
 
 
 # ------------------------------------------------------------------------------------
+# HA Core Version Tests
+# ------------------------------------------------------------------------------------
+
+
+def test_get_ha_core_version_no_token(mocker):
+    """Test get_ha_core_version when token is missing."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+    assert utils.get_ha_core_version() is None
+
+
+def test_get_ha_core_version_success(mocker):
+    """Test successful HA core version fetch."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = json.dumps({"data": {"version": "2025.5.0"}}).encode()
+    mock_response.__enter__ = lambda self: self
+    mock_response.__exit__ = lambda self, *args: None
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    assert utils.get_ha_core_version() == "2025.5.0"
+
+
+def test_get_ha_core_version_error(mocker):
+    """Test get_ha_core_version handles errors gracefully."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mocker.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("API Error"))
+    assert utils.get_ha_core_version() is None
+
+
+def test_parse_ha_version():
+    """Test HA version string parsing."""
+    assert utils.parse_ha_version("2025.5.0") == (2025, 5, 0)
+    assert utils.parse_ha_version("2025.5.0b1") == (2025, 5, 0)
+    assert utils.parse_ha_version("2025") == (2025,)
+    assert utils.parse_ha_version(None) == (0, 0, 0)
+    assert utils.parse_ha_version("") == (0, 0, 0)
+
+
+# ------------------------------------------------------------------------------------
 # Parse Localized Number Tests
 # ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.1-b23.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates.
- **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!

### Security
- **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.
```
