### PR TITLE
Release v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.1-b25] - 2026-05-10
+## [4.3.1] - 2026-05-10
 ### Changed
 - **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.1-b25"
+version: "4.3.1"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.1-b25"
+version = "4.3.1"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.1b25"
+version = "4.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.1.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates.
- **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
- **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!

### Security
- **Credentials**: Implemented Pydantic `SecretStr` for MQTT credentials to ensure automatic redaction in logs.
```
