### PR TITLE
Release v4.3.3-b7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,9 +148,9 @@ jobs:
 
           echo "Notable dependency updates: $DEPS"
 
-          # Replace the dependency line — matches both the generic placeholder
-          # and an already-enriched line from a previous beta
-          sed -i "s/- \*\*Dependencies\*\*: Dependency updates\( ([^)]*)\)\?\\./- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
+          # Replace the dependency line (first occurrence only — the current release entry)
+          # Matches both the generic placeholder and an already-enriched line from a previous beta
+          sed -i "0,/- \*\*Dependencies\*\*: Dependency updates\( ([^)]*)\)\?\\./s//- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
 
       - name: Commit and push bumped version
         if: steps.bump.outputs.did_bump == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.2] - 2026-05-11
 ### Changed
-- **Dependencies**: Dependency updates (serialx v1.8.0).
+- **Dependencies**: Dependency updates.
 
 ### Security
 - **SAST**: Resolved security scanning (SAST) warnings to ensure codebase integrity and security.
 
 ## [4.3.1] - 2026-05-10
 ### Changed
-- **Dependencies**: Dependency updates (serialx v1.8.0).
+- **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
 - **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!
 


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.3-b7.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates (serialx v1.8.0).
```
