### PR TITLE
Release v4.3.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.BETA_SYNC_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,14 +121,17 @@ jobs:
       - name: Enrich CHANGELOG dependency line
         if: steps.bump.outputs.did_bump == 'true'
         run: |
-          # Find the last tag to scope the commit range
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          # Find the last STABLE tag to scope the commit range (skip beta tags)
+          # This captures all Renovate commits across the entire beta cycle
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude "*-b*" HEAD 2>/dev/null || echo "")
           if [ -z "$PREV_TAG" ]; then
-            echo "No previous tag found, skipping dependency enrichment."
+            echo "No previous stable tag found, skipping dependency enrichment."
             exit 0
           fi
 
-          # Collect unique "fix(deps)" packages from Renovate commits since last tag
+          echo "Scanning Renovate commits since stable tag: $PREV_TAG"
+
+          # Collect unique "fix(deps)" packages from Renovate commits since last stable tag
           # Format: "fix(deps): update dependency <name> to <version>"
           # git log outputs newest-first, so sort -u keeps the latest version per package
           DEPS=$(git log "$PREV_TAG"..HEAD --author="renovate" --oneline \
@@ -144,8 +147,9 @@ jobs:
 
           echo "Notable dependency updates: $DEPS"
 
-          # Replace the generic placeholder with the enriched version
-          sed -i "s/- \*\*Dependencies\*\*: Dependency updates\./- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
+          # Replace the dependency line — matches both the generic placeholder
+          # and an already-enriched line from a previous beta
+          sed -i "s/- \*\*Dependencies\*\*: Dependency updates\( ([^)]*)\)\?\\./- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
 
       - name: Commit and push bumped version
         if: steps.bump.outputs.did_bump == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,9 +148,9 @@ jobs:
 
           echo "Notable dependency updates: $DEPS"
 
-          # Replace the dependency line — matches both the generic placeholder
-          # and an already-enriched line from a previous beta
-          sed -i "s/- \*\*Dependencies\*\*: Dependency updates\( ([^)]*)\)\?\\./- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
+          # Replace the dependency line (first occurrence only — the current release entry)
+          # Matches both the generic placeholder and an already-enriched line from a previous beta
+          sed -i "0,/- \*\*Dependencies\*\*: Dependency updates\( ([^)]*)\)\?\\./s//- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
 
       - name: Commit and push bumped version
         if: steps.bump.outputs.did_bump == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -366,7 +366,7 @@ jobs:
     name: Sync to Beta Repository
     needs: [check, manifest, release]
     runs-on: ubuntu-latest
-    if: github.ref_name == 'beta'
+    if: github.ref_name == 'beta' || github.ref_name == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,35 @@ jobs:
             echo "did_bump=false" >> $GITHUB_ENV
           fi
 
+      - name: Enrich CHANGELOG dependency line
+        if: steps.bump.outputs.did_bump == 'true'
+        run: |
+          # Find the last tag to scope the commit range
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, skipping dependency enrichment."
+            exit 0
+          fi
+
+          # Collect unique "fix(deps)" packages from Renovate commits since last tag
+          # Format: "fix(deps): update dependency <name> to <version>"
+          # git log outputs newest-first, so sort -u keeps the latest version per package
+          DEPS=$(git log "$PREV_TAG"..HEAD --author="renovate" --oneline \
+            | grep "^[a-f0-9]* fix(deps):" \
+            | sed -n 's/.*update dependency \(.*\) to \(.*\)/\1 \2/p' \
+            | sort -u -k1,1 \
+            | awk '{printf "%s%s %s", sep, $1, $2; sep=", "}')
+
+          if [ -z "$DEPS" ]; then
+            echo "No notable dependency updates found, keeping generic line."
+            exit 0
+          fi
+
+          echo "Notable dependency updates: $DEPS"
+
+          # Replace the generic placeholder with the enriched version
+          sed -i "s/- \*\*Dependencies\*\*: Dependency updates\./- **Dependencies**: Dependency updates ($DEPS)./" CHANGELOG.md
+
       - name: Commit and push bumped version
         if: steps.bump.outputs.did_bump == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b4] - 2026-05-13
+## [4.3.3-b5] - 2026-05-13
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b3] - 2026-05-13
+## [4.3.3-b4] - 2026-05-13
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b8] - 2026-05-13
+## [4.3.3] - 2026-05-14
 ### Changed
 - **Dependencies**: Dependency updates (serialx v1.8.0).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b2] - 2026-05-12
+## [4.3.3-b3] - 2026-05-13
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b5] - 2026-05-13
+## [4.3.3-b6] - 2026-05-13
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b6] - 2026-05-13
+## [4.3.3-b7] - 2026-05-13
 ### Changed
-- **Dependencies**: Dependency updates.
+- **Dependencies**: Dependency updates (serialx v1.8.0).
 
 ## [4.3.2] - 2026-05-11
 ### Changed
-- **Dependencies**: Dependency updates.
+- **Dependencies**: Dependency updates (serialx v1.8.0).
 
 ### Security
 - **SAST**: Resolved security scanning (SAST) warnings to ensure codebase integrity and security.
 
 ## [4.3.1] - 2026-05-10
 ### Changed
-- **Dependencies**: Dependency updates.
+- **Dependencies**: Dependency updates (serialx v1.8.0).
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
 - **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b0] - [unreleased]
+## [4.3.3-b1] - 2026-05-11
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.2] - 2026-05-11
 ### Changed
-- **Dependencies**: Dependency updates (serialx v1.8.0).
+- **Dependencies**: Dependency updates.
 
 ### Security
 - **SAST**: Resolved security scanning (SAST) warnings to ensure codebase integrity and security.
 
 ## [4.3.1] - 2026-05-10
 ### Changed
-- **Dependencies**: Dependency updates (serialx v1.8.0).
+- **Dependencies**: Dependency updates.
 - **Code Quality**: Added strict return type annotations to internal MQTT and Serial handler methods for improved reliability.
 - **Home Assistant Integration**: Transitioned the Startup Time diagnostic sensor to use the new `uptime` device class and `mdi:clock-start` icon. The add-on now dynamically detects your Home Assistant Core version via the Supervisor API and automatically falls back to the legacy `timestamp` class if you are running a version older than 2025.5.0!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.3-b0] - [unreleased]
+### Changed
+- **Dependencies**: Dependency updates.
+
 ## [4.3.2] - 2026-05-11
 ### Changed
 - **Dependencies**: Dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b7] - 2026-05-13
+## [4.3.3-b8] - 2026-05-13
 ### Changed
 - **Dependencies**: Dependency updates (serialx v1.8.0).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.3-b1] - 2026-05-11
+## [4.3.3-b2] - 2026-05-12
 ### Changed
 - **Dependencies**: Dependency updates.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:1025398289b62de8269e70c45b91ffa37c373f38118d7da036fb8bb8efc85d97 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:1025398289b62de8269e70c45b91ffa37c373f38118d7da036fb8bb8efc85d97 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+FROM python:3.14-alpine@sha256:a3de013592ea520507c1f18d880592338bd21abfe706237e68ed4126e21b6900
 
 LABEL org.opencontainers.image.title="S0PCM Reader (Standalone)" \
       org.opencontainers.image.description="Standalone S0PCM reader for non-Home Assistant environments" \

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b0"
+version: "4.3.3-b1"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b4"
+version: "4.3.3-b5"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b6"
+version: "4.3.3-b7"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b3"
+version: "4.3.3-b4"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b1"
+version: "4.3.3-b2"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b7"
+version: "4.3.3-b8"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b5"
+version: "4.3.3-b6"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b8"
+version: "4.3.3"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.3-b2"
+version: "4.3.3-b3"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.2"
+version: "4.3.3-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b3"
+version = "4.3.3-b4"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b8"
+version = "4.3.3"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b7"
+version = "4.3.3-b8"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b2"
+version = "4.3.3-b3"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.2"
+version = "4.3.3-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b4"
+version = "4.3.3-b5"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b0"
+version = "4.3.3-b1"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b1"
+version = "4.3.3-b2"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [
     "pyyaml==6.0.3",
-    "serialx==1.7.3",
+    "serialx==1.8.0",
     "paho-mqtt==2.1.0",
     "pydantic==2.13.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [
     "pyyaml==6.0.3",
-    "serialx==1.7.2",
+    "serialx==1.7.3",
     "paho-mqtt==2.1.0",
     "pydantic==2.13.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b6"
+version = "4.3.3-b7"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.3-b5"
+version = "4.3.3-b6"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -2,7 +2,7 @@
 # This container provides an isolated environment for running tests
 
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+FROM python:3.14-alpine@sha256:a3de013592ea520507c1f18d880592338bd21abfe706237e68ed4126e21b6900
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -15,7 +15,7 @@ WORKDIR /workspace
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:1025398289b62de8269e70c45b91ffa37c373f38118d7da036fb8bb8efc85d97 /uv /uvx /bin/
 
 # Install all deps (prod + test group)
 COPY pyproject.toml uv.lock ./

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -4,7 +4,7 @@ WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:1025398289b62de8269e70c45b91ffa37c373f38118d7da036fb8bb8efc85d97 /uv /uvx /bin/
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --system --no-cache -r - && \

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+FROM python:3.14-alpine@sha256:a3de013592ea520507c1f18d880592338bd21abfe706237e68ed4126e21b6900
 WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /

--- a/tests/standalone/simulator/Dockerfile
+++ b/tests/standalone/simulator/Dockerfile
@@ -1,4 +1,4 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+FROM python:3.14-alpine@sha256:a3de013592ea520507c1f18d880592338bd21abfe706237e68ed4126e21b6900
 COPY tests/standalone/simulator/simulator.py /simulator.py
 CMD ["python3", "-u", "/simulator.py"]

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+FROM python:3.14-alpine@sha256:a3de013592ea520507c1f18d880592338bd21abfe706237e68ed4126e21b6900
 WORKDIR /app
 
 # Install uv

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:1025398289b62de8269e70c45b91ffa37c373f38118d7da036fb8bb8efc85d97 /uv /uvx /bin/
 
 # Use the project's lock file for paho-mqtt version consistency
 COPY pyproject.toml uv.lock ./

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b3"
+version = "4.3.3b4"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b1"
+version = "4.3.3b2"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b7"
+version = "4.3.3b8"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b4"
+version = "4.3.3b5"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b8"
+version = "4.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b2"
+version = "4.3.3b3"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b6"
+version = "4.3.3b7"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.2"
+version = "4.3.3b1"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ requires-dist = [
     { name = "paho-mqtt", specifier = "==2.1.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "serialx", specifier = "==1.7.3" },
+    { name = "serialx", specifier = "==1.8.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -314,20 +314,20 @@ test = [
 
 [[package]]
 name = "serialx"
-version = "1.7.3"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/32/b5ccc6750b61f9f7eada3019acf3225bc674b6f93db87f763ea716a4101c/serialx-1.7.3.tar.gz", hash = "sha256:a654dec3c033a408750b5923da6d0ef6790246c3e3f54594e345d43b197a1572", size = 570325, upload-time = "2026-05-11T17:27:52.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/1a/9f0a4782cc08eeb6705960fc465cf3a70298774d63c3f86e22b84ddc9465/serialx-1.8.0.tar.gz", hash = "sha256:957843ec6d1fe91454e182884c29b614fb6d93209668f44197bcbb12d373129b", size = 570883, upload-time = "2026-05-13T06:43:19.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/5e/1767f9f6823d7b4141e84564d280ba7736d1f142ae2d349fe67f42dbcc05/serialx-1.7.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:83d601906ef92ad4676d844c0e1f3676bc7a132493ebc86b22229ef4abfe058f", size = 282810, upload-time = "2026-05-11T17:27:43.733Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ab/2d49e4d4cadf56a584f7b9d7bda2ae935560dbd662f6d3babf0dcb407911/serialx-1.7.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:33b60b8c0b97704497e6efa2c09cf8ac886d54e404942319a619b2cc1d41169a", size = 280358, upload-time = "2026-05-11T17:27:45.608Z" },
-    { url = "https://files.pythonhosted.org/packages/19/36/b2158e18d36add43428910f329b94e610a0da8336182059b6f47590775af/serialx-1.7.3-cp310-abi3-win32.whl", hash = "sha256:e5da0362ac4f3694c04a66f89095551ca5ae3f07fea194217a25ce1d24c18ecb", size = 181841, upload-time = "2026-05-11T17:27:47.456Z" },
-    { url = "https://files.pythonhosted.org/packages/22/39/70f1f8cc369fbc702f830f9b8714181a2e75e724cb3c44f6b3a972c5bf68/serialx-1.7.3-cp310-abi3-win_amd64.whl", hash = "sha256:da162dbcdca846778f098bdd382430f107990b9484f4037e7d26707dfd55a52b", size = 187849, upload-time = "2026-05-11T17:27:49.037Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e3/086113e05c891f93cb47dbd47668697501070d0d31aa0d2ff97fe60de2da/serialx-1.7.3-cp310-abi3-win_arm64.whl", hash = "sha256:94c6b24aecf3c8244367d2d937d8aab028e8e29b3e6026eeb82c9440cfc2e42f", size = 184153, upload-time = "2026-05-11T17:27:50.332Z" },
-    { url = "https://files.pythonhosted.org/packages/05/5f/ac1fa6a73461bf7a5b18763905cc7abb876c60f57abb06bac6b40e6922ab/serialx-1.7.3-py3-none-any.whl", hash = "sha256:f75315e3d05a002b8e33e8b0277ce1d4131d8e375c4117047f3a2caed17ae67b", size = 64354, upload-time = "2026-05-11T17:27:51.651Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b9/a949cf2a51e038dc55e903931a5e2177cfdbcc38a4fef0614bdd1292f94c/serialx-1.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:426a6586b81d1d8c80074b79852fcbc512e45dee2e677e44034cf977f6cfe7d0", size = 283010, upload-time = "2026-05-13T06:43:11.474Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d5/3fb88d6ddccf8685dd16f5bb4548857d0081a90724422950915c09069361/serialx-1.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b10770a949ac79583974853eaca887763b8ed1b03c249ce03401cd2c4664f084", size = 280557, upload-time = "2026-05-13T06:43:12.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/9b/6f13c8be34bc4f46189ebe572585d7e3d8481f7edd035a88bd20a838633e/serialx-1.8.0-cp310-abi3-win32.whl", hash = "sha256:c58b2dd3ed90e4a543d870afd60f0fe257888d2336b32fca7d3b32a55d4749f4", size = 182041, upload-time = "2026-05-13T06:43:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/48/e2/b5ff96e4f56a7d59dc2286f87a3e9c1ef619d4db05a10cfceb8ca38a2145/serialx-1.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:174127ed4307cc81c6dfaa9f6875f3f6075156348412aa1d31e4ee34fd64caf1", size = 188050, upload-time = "2026-05-13T06:43:15.643Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4a/65e4de353a30fa6b5078b4bee4fb722653203e72777107ac175572d48f2f/serialx-1.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:43419e09356c2da10fce7892f5930ce989785f621d3229364c9736771ddd80dd", size = 184355, upload-time = "2026-05-13T06:43:17.143Z" },
+    { url = "https://files.pythonhosted.org/packages/58/79/5292b2fd3c6e1c5bca04d04c646cc560a0d2a98590180361da1c4643fc40/serialx-1.8.0-py3-none-any.whl", hash = "sha256:650f12a33d7ddf4068c6a234c9ae1b015d92ab65b714b08def90274f555c35ab", size = 64556, upload-time = "2026-05-13T06:43:18.321Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ requires-dist = [
     { name = "paho-mqtt", specifier = "==2.1.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "serialx", specifier = "==1.7.2" },
+    { name = "serialx", specifier = "==1.7.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -314,20 +314,20 @@ test = [
 
 [[package]]
 name = "serialx"
-version = "1.7.2"
+version = "1.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/ad/bb2566ff39c10d4683a38cbdd78f79d891d2c7c6dfd5a73664db9cd77da6/serialx-1.7.2.tar.gz", hash = "sha256:29e3b7fae7bfa9253e5b299b847ebd9ed537357558eb3128eb4079a178a644dc", size = 565568, upload-time = "2026-05-06T20:48:14.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/32/b5ccc6750b61f9f7eada3019acf3225bc674b6f93db87f763ea716a4101c/serialx-1.7.3.tar.gz", hash = "sha256:a654dec3c033a408750b5923da6d0ef6790246c3e3f54594e345d43b197a1572", size = 570325, upload-time = "2026-05-11T17:27:52.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/61/64c18aa14229820b8561da82c28233ce3fae1fbd12672409d559e4f09c2b/serialx-1.7.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:96fbcc2244d889b912fe5c80a06693881c8c0ffd188df7d286f88b639764cacd", size = 281863, upload-time = "2026-05-06T20:48:06.254Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/79/39084430e47e40d0411a226d702f8811056fa24123a4a79d9c8c29fd560d/serialx-1.7.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7b9fb35b7a9a954a1f4c8793aae1cf710d558682063216884aa74a42be1361ec", size = 279410, upload-time = "2026-05-06T20:48:07.721Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/86/82355cdf34904f9c49e4e0a34df13f3feb5465714dd016ffe70f7b5c0505/serialx-1.7.2-cp310-abi3-win32.whl", hash = "sha256:48543a67830740b32174fcaa8636a70744fe5f575c4cc7812262f5ac7c10cae2", size = 180891, upload-time = "2026-05-06T20:48:08.987Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/4d/9951ab6f99d5537d9e5fcc0192f6ac422ee8a6073013dc667921715edefe/serialx-1.7.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd02aa8b4c293e8fba5268103e5bfd78767980f36faaba5d913877e482a8bc3", size = 186897, upload-time = "2026-05-06T20:48:10.507Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/49/73371735e7d4e9e32cb0dc11443df70de0cdd1f42b721b86f3a4f927db70/serialx-1.7.2-cp310-abi3-win_arm64.whl", hash = "sha256:717283d86c34ccac4faa782e6ab61d8c32645f1b0f7b01396c31e5e6b6df8118", size = 183202, upload-time = "2026-05-06T20:48:11.814Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/41/a8c19071bf60cbf6e0acff4dc3769cf2e705dd1e1a3d11438d82764f078e/serialx-1.7.2-py3-none-any.whl", hash = "sha256:0b5485a1a4b3e0b2f1f80fe84b7c40fb679d55265f7fb805912a7f52f6585e3d", size = 63406, upload-time = "2026-05-06T20:48:13.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5e/1767f9f6823d7b4141e84564d280ba7736d1f142ae2d349fe67f42dbcc05/serialx-1.7.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:83d601906ef92ad4676d844c0e1f3676bc7a132493ebc86b22229ef4abfe058f", size = 282810, upload-time = "2026-05-11T17:27:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ab/2d49e4d4cadf56a584f7b9d7bda2ae935560dbd662f6d3babf0dcb407911/serialx-1.7.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:33b60b8c0b97704497e6efa2c09cf8ac886d54e404942319a619b2cc1d41169a", size = 280358, upload-time = "2026-05-11T17:27:45.608Z" },
+    { url = "https://files.pythonhosted.org/packages/19/36/b2158e18d36add43428910f329b94e610a0da8336182059b6f47590775af/serialx-1.7.3-cp310-abi3-win32.whl", hash = "sha256:e5da0362ac4f3694c04a66f89095551ca5ae3f07fea194217a25ce1d24c18ecb", size = 181841, upload-time = "2026-05-11T17:27:47.456Z" },
+    { url = "https://files.pythonhosted.org/packages/22/39/70f1f8cc369fbc702f830f9b8714181a2e75e724cb3c44f6b3a972c5bf68/serialx-1.7.3-cp310-abi3-win_amd64.whl", hash = "sha256:da162dbcdca846778f098bdd382430f107990b9484f4037e7d26707dfd55a52b", size = 187849, upload-time = "2026-05-11T17:27:49.037Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e3/086113e05c891f93cb47dbd47668697501070d0d31aa0d2ff97fe60de2da/serialx-1.7.3-cp310-abi3-win_arm64.whl", hash = "sha256:94c6b24aecf3c8244367d2d937d8aab028e8e29b3e6026eeb82c9440cfc2e42f", size = 184153, upload-time = "2026-05-11T17:27:50.332Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5f/ac1fa6a73461bf7a5b18763905cc7abb876c60f57abb06bac6b40e6922ab/serialx-1.7.3-py3-none-any.whl", hash = "sha256:f75315e3d05a002b8e33e8b0277ce1d4131d8e375c4117047f3a2caed17ae67b", size = 64354, upload-time = "2026-05-11T17:27:51.651Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.3b5"
+version = "4.3.3b6"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },


### PR DESCRIPTION
Automated stable release PR for version 4.3.3.

### Changes in this release:
- Merge pull request #222 from darkrain-nl/renovate/serialx-1.x
- Merge pull request #220 from darkrain-nl/renovate/ghcr.io-astral-sh-uv
- Merge pull request #218 from darkrain-nl/renovate/python-3.14-alpine
- Merge pull request #217 from darkrain-nl/renovate/serialx-1.x

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates (serialx v1.8.0).
```
