### PR TITLE
Release v4.3.4-b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependencies**: Dependency updates
 
+### Security
+- **AppArmor Profile**: Hardened the AppArmor profile by stripping the dangerous global `file,` capability, explicitly whitelisting only the required S6-overlay and application directories for maximum container isolation.
+- **Root Privileges**: Hardened the Docker container by executing the main Python application as a restricted, non-root `s0pcm` user (via `s6-setuidgid`) while securely retaining serial port access through the `dialout` group.
+
 ## [4.3.3] - 2026-05-14
 ### Changed
 - **Dependencies**: Dependency updates (serialx v1.8.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --link-mode=copy --system -r - && \
     cd / && rm -rf /tmp/uv && \
-    chmod a+x /etc/services.d/s0pcm-reader/*
+    chmod a+x /etc/services.d/s0pcm-reader/* && \
+    addgroup -S s0pcm && adduser -S -D -H -h /usr/src -s /sbin/nologin -G s0pcm -g s0pcm s0pcm && \
+    addgroup s0pcm dialout && \
+    chown -R s0pcm:s0pcm /usr/src
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python3 /usr/src/healthcheck.py || exit 1

--- a/apparmor.txt
+++ b/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile s0pcm_reader flags=(attach_disconnected,mediate_deleted,complain) {
+profile s0pcm_reader flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   
   # Network and Process Management

--- a/rootfs/etc/services.d/s0pcm-reader/run
+++ b/rootfs/etc/services.d/s0pcm-reader/run
@@ -38,4 +38,5 @@ fi
 
 echo "$(date +'%Y-%m-%d %H:%M:%S,000') INFO: Starting S0PCM Reader..."
 export S0PCM_READER_VERSION=$(bashio::addon.version)
-exec python3 /usr/src/s0pcm_reader.py
+chown -R s0pcm:s0pcm /data
+exec s6-setuidgid s0pcm python3 /usr/src/s0pcm_reader.py


### PR DESCRIPTION
Automated merge of dev into beta for release v4.3.4-b7.

### Changes in this release:

### Changelog entries:
```markdown
### Changed
- **Dependencies**: Dependency updates

### Security
- **AppArmor Profile**: Hardened the AppArmor profile by stripping the dangerous global `file,` capability, explicitly whitelisting only the required S6-overlay and application directories for maximum container isolation.
- **Root Privileges**: Hardened the Docker container by executing the main Python application as a restricted, non-root `s0pcm` user (via `s6-setuidgid`) while securely retaining serial port access through the `dialout` group.
```
