### PR TITLE
chore: sync renovate.json from dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,10 @@
         ":separateMajorReleases",
         ":combinePatchMinorReleases",
         ":disableDependencyDashboard",
-        ":rebaseStalePrs"
+        "helpers:pinGitHubActionDigests",
+        "docker:pinDigests"
     ],
-    "minimumReleaseAge": "3 days",
+    "rebaseWhen": "conflicted",
     "baseBranchPatterns": [
         "dev"
     ],
@@ -25,7 +26,11 @@
         ]
     },
     "lockFileMaintenance": {
-        "enabled": true
+        "enabled": true,
+        "automerge": true,
+        "schedule": [
+            "before 5am on monday"
+        ]
     },
     "customManagers": [
         {
@@ -43,7 +48,15 @@
     ],
     "packageRules": [
         {
-            "matchManagers": ["github-actions"],
+            "matchDatasources": [
+                "pypi"
+            ],
+            "minimumReleaseAge": "3 days"
+        },
+        {
+            "matchManagers": [
+                "github-actions"
+            ],
             "minimumReleaseAge": "5 days"
         },
         {
@@ -51,6 +64,17 @@
                 "ghcr.io/home-assistant/**"
             ],
             "groupName": "Home Assistant Base Images"
+        },
+        {
+            "description": "Automerge Docker digest updates weekly to prevent perpetual force-push cycles",
+            "matchUpdateTypes": [
+                "digest"
+            ],
+            "schedule": [
+                "before 5am on monday"
+            ],
+            "automerge": true,
+            "automergeType": "pr"
         }
     ]
 }


### PR DESCRIPTION
Sync renovate.json from dev to main to pick up recent changes.