### PR TITLE
fix: correct renovate regex manager template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,10 +40,11 @@
                 "/(^|/)build\\.yaml$/"
             ],
             "matchStrings": [
-                "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>\\S+)"
+                "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "docker"
+            "versioningTemplate": "docker",
+            "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
Fixes 'Error updating branch' in Renovate by providing the correct `autoReplaceStringTemplate` for the regex manager to handle Docker digest pinning.