### PR TITLE
fix: disable digest pinning for HA base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,8 @@
             "matchPackageNames": [
                 "ghcr.io/home-assistant/**"
             ],
-            "groupName": "Home Assistant Base Images"
+            "groupName": "Home Assistant Base Images",
+            "pinDigests": false
         },
         {
             "description": "Automerge Docker digest updates weekly to prevent perpetual force-push cycles",


### PR DESCRIPTION
Disables digest pinning for Home Assistant Base images to prevent Renovate 'update failure' crashes during regex replacements.