### PR TITLE
Release v5.0.0-b1

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -160,7 +160,7 @@ The app uses a dual-layer recovery system:
 **Note**: If you wipe both MQTT and restart HA simultaneously, data may be lost. **Always backup your MQTT broker.**
 
 ## 8. Technical Details
-- **Architecture**: Multithreaded Python app.
+- **Architecture**: Asynchronous Python application running on a single-threaded asyncio event loop.
 - **Discovery**: Follows Home Assistant MQTT Discovery standard.
 - **Topics**:
     - Data: `s0pcmreader/<ID>/total`

--- a/tests/README.md
+++ b/tests/README.md
@@ -124,12 +124,10 @@ The `docker-test.sh` (Linux) and `docker-test.ps1` (Windows) scripts perform the
 If running in a strictly read-only environment, the cache provider is disabled via `pytest.ini` (`-p no:cacheprovider`) to prevent `PytestCacheWarning`.
 
 ### Tests Hanging
-Hanging tests usually indicate an unstopped thread. Ensure all `threading.Event` objects (like `stopper`) are set during cleanup:
-```python
-stopper.set()
-trigger.set()
-thread.join(timeout=5)
-```
+Hanging tests usually indicate an unstopped asynchronous task or a coroutine that is running indefinitely (e.g., an infinite loop in a background task). Ensure:
+1. Any background loop has a clean exit condition or handles `asyncio.CancelledError` properly.
+2. Background tasks created on the event loop (e.g., via `asyncio.create_task` or within a `TaskGroup`) are cancelled and awaited during test cleanup.
+3. Tests use `pytest-timeout` to fail automatically if they exceed a specific duration, rather than hanging indefinitely.
 
 ### Script Execution Policy (Windows)
 If `.ps1` scripts are blocked, run:
@@ -138,4 +136,4 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 ```
 
 ---
-*Last updated: 2026-05-02*
+*Last updated: 2026-06-14*

--- a/tests/test_mqtt_handler.py
+++ b/tests/test_mqtt_handler.py
@@ -509,6 +509,227 @@ class TestMQTTAdditionalCoverage:
         assert _resolve_meter_id(mqtt_context, "NonExistent") is None
         assert _resolve_meter_id(mqtt_context, "1") == 1  # Numeric ID
 
+    async def test_message_listener(self, mqtt_context, mocker):
+        """Test _message_listener processes set/name commands."""
+        from mqtt_handler import MqttTaskState, _message_listener
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+
+        # Create mock messages
+        msg1 = MagicMock()
+        msg1.topic = "s0pcmreader/1/total/set"
+        msg1.payload = b"2000"
+
+        msg2 = MagicMock()
+        msg2.topic = "s0pcmreader/2/name/set"
+        msg2.payload = b"Gas"
+
+        async def mock_messages():
+            yield msg1
+            yield msg2
+
+        mock_client.messages = mock_messages()
+
+        mock_handle_set = mocker.patch("mqtt_handler._handle_set_command", new_callable=AsyncMock)
+        mock_handle_name_set = mocker.patch("mqtt_handler._handle_name_set", new_callable=AsyncMock)
+
+        await _message_listener(mqtt_context, mock_client, task_state)
+
+        mock_handle_set.assert_called_once_with(mqtt_context, "s0pcmreader/1/total/set", b"2000")
+        mock_handle_name_set.assert_called_once_with(
+            mqtt_context, mock_client, task_state, "s0pcmreader/2/name/set", b"Gas"
+        )
+
+    async def test_publish_loop_global_discovery(self, mqtt_context, mocker):
+        """Test that _publish_loop sends global discovery and cleans up ghost meters."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+
+        mock_send_global = mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mock_cleanup = mocker.patch("mqtt_handler.discovery.cleanup_meter_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock)
+
+        # Make trigger event fire once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        assert mock_send_global.call_count == 1
+        assert mock_cleanup.call_count == 5
+        assert task_state.global_discovery_sent is True
+
+    async def test_publish_loop_delayed_clear(self, mqtt_context, mocker):
+        """Test that delayed_clear background task clears the MQTT error."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+        task_state.global_discovery_sent = True
+
+        # Set error message on context
+        mqtt_context.set_error("MQTT Connect Fail", category="mqtt", trigger_event=False)
+
+        # Mock asyncio.sleep dynamically using original sleep to yield control properly
+        original_sleep = asyncio.sleep
+
+        async def mock_sleep(delay, result=None):
+            await original_sleep(0)
+
+        mocker.patch("asyncio.sleep", new=mock_sleep)
+
+        # Trigger event once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        # Verify the error was published
+        mock_client.publish.assert_any_call("s0pcmreader/error", "MQTT Connect Fail", retain=True)
+
+        # Ensure the background task completed and called set_error(None)
+        await original_sleep(0.05)  # yield control so task executes
+
+        assert mqtt_context.lasterror_mqtt is None
+
+    async def test_publish_loop_publish_error_exception(self, mqtt_context, mocker):
+        """Test that _publish_loop logs an error when publish fails."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+
+        async def publish_side_effect(topic, *args, **kwargs):
+            if topic.endswith("/error"):
+                raise Exception("Publish error")
+
+        mock_client.publish = AsyncMock(side_effect=publish_side_effect)
+        task_state = MqttTaskState()
+
+        # Make error_msg different to trigger publish
+        mqtt_context.set_error("Connect fail", category="mqtt", trigger_event=False)
+
+        mocker.patch("mqtt_handler.logger.error")
+
+        # Trigger event once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        import mqtt_handler
+
+        mqtt_handler.logger.error.assert_called_with("MQTT Publish Failed for error: Publish error")
+
+    async def test_mqtt_task_tls_build_fail(self, mqtt_context, mocker):
+        """Test that mqtt_task retries and sleeps when TLS configuration fails."""
+        from mqtt_handler import mqtt_task
+
+        mqtt_context.config = make_test_config(tls=True)
+        mocker.patch("mqtt_handler._build_ssl_context", return_value=None)
+        mocker.patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()])
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+    async def test_mqtt_task_connection_success(self, mqtt_context, mocker):
+        """Test that mqtt_task connects, runs recovery, and sets up TaskGroup listeners successfully on happy path."""
+        from mqtt_handler import mqtt_task
+
+        mock_client = AsyncMock()
+        # Mock the context manager
+        mock_client_cm = MagicMock()
+        mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+        mocker.patch("mqtt_handler.aiomqtt.Client", return_value=mock_client_cm)
+
+        # Mock StateRecoverer
+        mock_recoverer = MagicMock()
+        mock_recoverer.run = AsyncMock()
+        mocker.patch("mqtt_handler.StateRecoverer", return_value=mock_recoverer)
+
+        # Mock TaskGroup to instantly raise CancelledError to break out after starting tasks
+        class MockTaskGroup:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                raise asyncio.CancelledError()
+
+            def create_task(self, coro):
+                pass
+
+        mocker.patch("asyncio.TaskGroup", return_value=MockTaskGroup())
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+        # Verify recovery ran, status published, subscriptions made
+        mock_recoverer.run.assert_called_once()
+        mock_client.publish.assert_any_call("s0pcmreader/status", "online", retain=True)
+        mock_client.subscribe.assert_any_call("s0pcmreader/+/total/set")
+        mock_client.subscribe.assert_any_call("s0pcmreader/+/name/set")
+        assert mqtt_context.recovery_event.is_set()
+
+    async def test_mqtt_task_connection_fail(self, mqtt_context, mocker):
+        """Test that mqtt_task sets error state and retries on broker connection failure."""
+        from mqtt_handler import mqtt_task
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__aenter__ = AsyncMock(side_effect=Exception("Connection Failed"))
+        mocker.patch("mqtt_handler.aiomqtt.Client", return_value=mock_client_cm)
+
+        mocker.patch("asyncio.sleep", side_effect=asyncio.CancelledError)
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+        assert "MQTT connection failed" in mqtt_context.lasterror_mqtt
+
+    async def test_mqtt_task_fatal_exception_outer(self, mocker):
+        """Test outer Exception handler in mqtt_task."""
+        from mqtt_handler import mqtt_task
+
+        context = state_module.get_context()
+        context.config = None  # This will trigger AttributeError when accessing context.config.mqtt.tls
+
+        mocker.patch("mqtt_handler.logger.error")
+
+        await mqtt_task(context)
+
+        import mqtt_handler
+
+        mqtt_handler.logger.error.assert_called_with("Fatal MQTT exception", exc_info=True)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -9,6 +9,7 @@ Tests cover:
 - Complete recovery flow and edge cases
 """
 
+import asyncio
 import datetime
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -329,6 +330,34 @@ class TestRecoveryFlow:
 
         # Verify unsubscriptions
         assert recoverer.client.unsubscribe.call_count == 6
+
+    async def test_run_receives_retained_messages_and_timeouts(self, recoverer, mocker):
+        """Test that run() successfully processes received messages and handles TimeoutError gracefully."""
+
+        # Yield a couple of messages, then wait to trigger TimeoutError
+        async def message_generator():
+            msg1 = MagicMock()
+            msg1.topic = "s0pcmreader/1/total"
+            msg1.payload = b"12345"
+            yield msg1
+
+            msg2 = MagicMock()
+            msg2.topic = "s0pcmreader/Water/name"
+            msg2.payload = b"Water"
+            yield msg2
+
+            await asyncio.sleep(0.05)  # sleep to let timeout happen
+
+        recoverer.client.messages = message_generator()
+
+        # Set recovery wait to a very small value so timeout is quick
+        recoverer.context.config.mqtt.recovery_wait = 0.01
+
+        await recoverer.run()
+
+        # Check that the messages were processed and saved to recovered_data
+        assert "1" in recoverer.recovered_data
+        assert recoverer.recovered_data["1"]["total"] == 12345
 
     async def test_run_initializes_meters_from_mqtt_data(self, recoverer, mocker):
         """Test that run() initializes meters from recovered MQTT data."""

--- a/tests/test_s0pcm_reader.py
+++ b/tests/test_s0pcm_reader.py
@@ -2,7 +2,8 @@
 Tests for main module (s0pcm_reader.py).
 """
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -52,6 +53,60 @@ def test_init_args_coverage():
         mock_parse.return_value.config = "/tmp/test"
         result_path = config_module_imp.init_args()
         assert str(result_path) == "/tmp/test"
+
+
+async def test_main_signal_handler(mocker):
+    """Test signal handler registration and execution."""
+    import s0pcm_reader
+
+    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.mqtt_task", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.logger")
+
+    mock_loop = MagicMock()
+    mocker.patch("asyncio.get_running_loop", return_value=mock_loop)
+
+    mock_task = MagicMock()
+    mocker.patch("asyncio.all_tasks", return_value={mock_task})
+
+    await s0pcm_reader.main()
+
+    # Verify add_signal_handler was called for SIGINT and SIGTERM
+    assert mock_loop.add_signal_handler.call_count == 2
+
+    # Extract the registered signal handler function
+    sig_handler = mock_loop.add_signal_handler.call_args[0][1]
+
+    # Call the signal handler
+    sig_handler()
+
+    # Verify it cancelled the tasks
+    mock_task.cancel.assert_called_once()
+
+
+async def test_main_cancellation_handling(mocker):
+    """Test that main() handles CancelledError ExceptionGroup gracefully."""
+    import s0pcm_reader
+
+    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.logger")
+
+    # Mock TaskGroup to raise BaseExceptionGroup containing CancelledError
+    class MockTaskGroup:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            raise BaseExceptionGroup("group", [asyncio.CancelledError()])
+
+        def create_task(self, coro):
+            pass
+
+    mocker.patch("asyncio.TaskGroup", return_value=MockTaskGroup())
+
+    # This should run without raising because BaseExceptionGroup containing CancelledError is caught by except*
+    await s0pcm_reader.main()
 
 
 if __name__ == "__main__":

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -362,5 +362,36 @@ async def test_log_available_ports_called_on_first_failure(mocker):
     mock_log_ports.assert_called_once()
 
 
+async def test_read_loop_cancelled_error():
+    """Test _read_loop raises CancelledError on cancellation."""
+    from serial_handler import _read_loop
+
+    context = state_module.get_context()
+    mock_serial = AsyncMock()
+    mock_serial.readline = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await _read_loop(context, mock_serial)
+
+
+async def test_serial_task_fatal_exception_outer(mocker):
+    """Test outer Exception block in serial_task."""
+    from serial_handler import serial_task
+
+    context = state_module.get_context()
+    context.config = make_test_config()
+
+    # Mock recovery_event.wait to raise an exception
+    mocker.patch.object(context.recovery_event, "wait", side_effect=ValueError("Fatal Wait Error"))
+    mocker.patch("serial_handler.logger.error")
+
+    await serial_task(context)
+
+    # Verify logger.error was called with fatal exception info
+    import serial_handler
+
+    serial_handler.logger.error.assert_called_with("Fatal exception in Serial Task", exc_info=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b1.

### Changes in this release:

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
