### PR TITLE
Release v5.0.0-b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0-b2] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
+- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 
 ### Security

--- a/DOCS.md
+++ b/DOCS.md
@@ -45,7 +45,7 @@ services:
 ## 3. Configuration
 
 ### General Options
-- **Device**: Path to the USB device (e.g., `/dev/ttyACM0`).
+- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left blank or set to `null` (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip).
 - **Log Level**: (Default: `info`) Set logging verbosity (`debug`, `info`, `warning`, `error`, `critical`).
 
 ### Connection Settings

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Only the latest version of the app is supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | Latest  | :white_check_mark: |
-| < 4.0.0 | :x:                |
+| < 5.0.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ options:
     tls_port: 8883
   log_level: info
 schema:
-  device: device(subsystem=tty)
+  device: device(subsystem=tty)?
   mqtt:
     host: str?
     port: port?

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -93,6 +93,43 @@ def init_args() -> Path:
     return config_path
 
 
+def _auto_detect_serial_port() -> str:
+    """
+    Auto-detect the S0PCM serial port on the system.
+
+    Looks for typical CH340 USB-serial chips first, then any USB-serial device.
+    """
+    try:
+        ports = serialx.list_serial_ports()
+        if not ports:
+            logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
+            return "/dev/ttyACM0"
+
+        # 1. Look for known S0PCM CH340 USB-serial chip (Vendor ID 0x1a86 or "1a86" in device name)
+        for p in ports:
+            is_ch340_vid = p.vid == 0x1A86
+            is_ch340_str = "1a86" in p.device.lower() or (
+                p.manufacturer is not None and "1a86" in p.manufacturer.lower()
+            )
+            if is_ch340_vid or is_ch340_str:
+                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' (CH340)")
+                return p.device
+
+        # 2. Look for any other USB serial port (has "usb" in path or description)
+        for p in ports:
+            if "usb" in p.device.lower() or (p.description is not None and "usb" in p.description.lower()):
+                logger.info(f"Auto-detect: Selecting first available USB serial port '{p.device}' ({p.description})")
+                return p.device
+
+        # 3. Fallback to the first available port
+        first_port = ports[0].device
+        logger.info(f"Auto-detect: No USB-serial candidate found. Selecting first port '{first_port}'")
+        return first_port
+    except Exception as e:
+        logger.error(f"Auto-detect: Exception during port scan: {e}. Defaulting to /dev/ttyACM0")
+        return "/dev/ttyACM0"
+
+
 def read_config(
     version: str = "Unknown",
     config_dir: Path = Path("./"),
@@ -136,9 +173,12 @@ def read_config(
         if not tls_ca_path.is_absolute():
             tls_ca = str(config_dir / tls_ca)
 
+    device_opt = ha_options.get("device")
+    resolved_port = _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
+
     model = ConfigModel(
         log=LogConfig(level=(ha_options.get("log_level") or "INFO").upper()),
-        serial=SerialConfig(port=ha_options.get("device", "/dev/ttyACM0")),
+        serial=SerialConfig(port=resolved_port),
         mqtt=MqttConfig(
             host=mqtt_opts.get("host") or mqtt_service.get("host", "127.0.0.1"),
             port=mqtt_opts.get("port") or mqtt_service.get("port", 1883),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,7 +106,7 @@ class TestConfigCoverage:
         ):
             config_module.read_config()
             assert mock_logger.called
-            assert "Failed to load" in mock_logger.call_args[0][0]
+            assert any("Failed to load" in str(c) for c in mock_logger.call_args_list)
 
     def test_read_config_mqtt_discovery_log(self, mocker):
         """Test logging when MQTT service discovery is used (line 126)."""
@@ -132,6 +132,72 @@ class TestConfigCoverage:
         model = config_module.read_config()
         assert model.mqtt.version == "5.0"
         assert isinstance(model.mqtt.version, str)
+
+
+class TestAutoDetectSerialPort:
+    def test_auto_detect_no_ports(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        with patch("config.logger.warning") as mock_warn:
+            port = config_module._auto_detect_serial_port()
+            assert port == "/dev/ttyACM0"
+            mock_warn.assert_called_once()
+            assert "No serial ports detected" in mock_warn.call_args[0][0]
+
+    def test_auto_detect_ch340_vid(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyUSB99"
+        mock_port.vid = 0x1A86
+        mock_port.manufacturer = "CH340 Manufacturer"
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyUSB99"
+
+    def test_auto_detect_ch340_name(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
+        mock_port.vid = 0x1234
+        mock_port.manufacturer = None
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
+
+    def test_auto_detect_generic_usb(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
+        mock_port.vid = 0x0403
+        mock_port.manufacturer = "FTDI"
+        mock_port.description = "FTDI USB Serial"
+
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
+
+    def test_auto_detect_fallback_first(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyS0"
+        mock_port.vid = None
+        mock_port.manufacturer = None
+        mock_port.description = "Standard Serial Port"
+
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyS0"
+
+    def test_auto_detect_exception(self, mocker):
+        mocker.patch("serialx.list_serial_ports", side_effect=RuntimeError("Scan error"))
+        with patch("config.logger.error") as mock_error:
+            port = config_module._auto_detect_serial_port()
+            assert port == "/dev/ttyACM0"
+            mock_error.assert_called_once()
+            assert "Exception during port scan" in mock_error.call_args[0][0]
+
+    def test_read_config_triggers_auto_detect(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        mocker.patch("pathlib.Path.exists", return_value=True)
+        mocker.patch("pathlib.Path.read_text", return_value=json.dumps({"device": None}))
+
+        model = config_module.read_config()
+        assert model.serial.port == "/dev/ttyACM0"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b2.

### Changes in this release:

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
