### PR TITLE
Release v5.0.0-b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 
+### Fixed
+- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
+- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.
+
 ### Security
 - **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
 - **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.

--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,8 @@ init: false
 startup: application
 hassio_api: true
 homeassistant_api: true
+uart: true
 options:
-  device: null
   mqtt:
     base_topic: "s0pcmreader"
     protocol: "5.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,6 +199,14 @@ class TestAutoDetectSerialPort:
         model = config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
+    def test_read_config_triggers_auto_detect_missing_key(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        mocker.patch("pathlib.Path.exists", return_value=True)
+        mocker.patch("pathlib.Path.read_text", return_value=json.dumps({}))
+
+        model = config_module.read_config()
+        assert model.serial.port == "/dev/ttyACM0"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -1,7 +1,7 @@
 configuration:
   device:
     name: "Serial Port"
-    description: "The serial port device where your S0PCM is connected (Default: /dev/ttyACM0)."
+    description: "Optional. The serial port device where your S0PCM is connected (Default: auto-detect). Enable 'Show unused optional configuration options' to manually select a port."
   mqtt:
     name: "Basic MQTT Settings"
     description: "Leave these fields empty if you use Home Assistant OS with the Mosquitto broker App! We will automatically connect."


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b3.

### Changes in this release:

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Fixed
- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
