### PR TITLE
Release v5.0.0-b4

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,8 +9,7 @@ This application reads pulse counts from S0PCM-2 (2-channel) or S0PCM-5 (5-chann
 ### Home Assistant App (Recommended)
 1. Add the repository: `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader`
 2. Install **S0PCM Reader** from the App Store.
-3. Configure the **Device** (e.g., `/dev/ttyACM0`) in the Configuration tab.
-4. Start the app.
+3. Start the app. By default, it will auto-detect your connected S0PCM reader. (Optional: To manually select a port, enable "Show unused optional configuration options" in the Configuration tab).
 
 ### Standalone Docker Container (Advanced)
 If you are not using Home Assistant OS/Supervisor, you can run this as a standalone container.
@@ -45,7 +44,7 @@ services:
 ## 3. Configuration
 
 ### General Options
-- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left blank or set to `null` (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip).
+- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left unconfigured (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip). In the Home Assistant UI, this field is hidden under the "Show unused optional configuration options" toggle by default.
 - **Log Level**: (Default: `info`) Set logging verbosity (`debug`, `info`, `warning`, `error`, `critical`).
 
 ### Connection Settings

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ An easy-to-use Home Assistant App that reads pulse counters from an **S0PCM-2** 
 1. Add this repository to your Home Assistant App Store:
    `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader`
 2. Search for **S0PCM Reader** and click **Install**.
-3. Navigate to the **Configuration** tab.
-4. Select your **S0PCM USB device** (e.g., `/dev/ttyACM0`).
-5. **Start** the app.
+3. **Start** the app. By default, it will auto-detect your connected S0PCM USB device. (Optional: To customize settings or manually configure the port, open the **Configuration** tab).
 
 ### Beta version
 If you want to help test upcoming features, you can install the Beta version. You can install both the Beta and Stable versions at the same time without conflicts.
@@ -39,7 +37,7 @@ If you want to help test upcoming features, you can install the Beta version. Yo
    `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader-beta`
 2. Search for **S0PCM Reader (Beta)** and click **Install**.
 3. Go to your Stable **S0PCM Reader**, **Stop** it, and disable **Start on boot**.
-4. Go to **S0PCM Reader (Beta)**, configure your USB device, and **Start** it.
+4. Go to **S0PCM Reader (Beta)** and click **Start** (it will auto-detect your USB device by default).
 
 ## 📖 Documentation
 


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b4.

### Changes in this release:

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Fixed
- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
