### PR TITLE
Release v5.0.0-b5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 
 LABEL org.opencontainers.image.title="S0PCM Reader (Standalone)" \
       org.opencontainers.image.description="Standalone S0PCM reader for non-Home Assistant environments" \

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -6,6 +6,7 @@ Home Assistant options.json and Supervisor API.
 """
 
 import argparse
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -93,14 +94,14 @@ def init_args() -> Path:
     return config_path
 
 
-def _auto_detect_serial_port() -> str:
+async def _auto_detect_serial_port() -> str:
     """
     Auto-detect the S0PCM serial port on the system.
 
     Looks for typical CH340 USB-serial chips first, then any USB-serial device.
     """
     try:
-        ports = serialx.list_serial_ports()
+        ports = await asyncio.to_thread(serialx.list_serial_ports)
         if not ports:
             logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
             return "/dev/ttyACM0"
@@ -130,7 +131,7 @@ def _auto_detect_serial_port() -> str:
         return "/dev/ttyACM0"
 
 
-def read_config(
+async def read_config(
     version: str = "Unknown",
     config_dir: Path = Path("./"),
 ) -> ConfigModel:
@@ -147,16 +148,21 @@ def read_config(
     # 1. Load Home Assistant Options
     options_path = Path("/data/options.json")
     ha_options = {}
-    if options_path.exists():
-        try:
-            ha_options = json.loads(options_path.read_text())
-        except Exception as e:
-            logger.error(f"Failed to load {options_path}: {e}")
+
+    def _read_options():
+        if options_path.exists():
+            try:
+                return json.loads(options_path.read_text())
+            except Exception as e:
+                logger.error(f"Failed to load {options_path}: {e}")
+        return {}
+
+    ha_options = await asyncio.to_thread(_read_options)
 
     # 2. MQTT Service Discovery
     mqtt_service = {}
     if not ha_options.get("mqtt_host"):
-        mqtt_service = get_supervisor_config("mqtt")
+        mqtt_service = await get_supervisor_config("mqtt")
         if mqtt_service:
             logger.info("Using MQTT service discovery for connection settings.")
 
@@ -174,7 +180,7 @@ def read_config(
             tls_ca = str(config_dir / tls_ca)
 
     device_opt = ha_options.get("device")
-    resolved_port = _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
+    resolved_port = await _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
 
     model = ConfigModel(
         log=LogConfig(level=(ha_options.get("log_level") or "INFO").upper()),

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -81,7 +81,7 @@ async def send_global_discovery(client: aiomqtt.Client, context: AppContext) -> 
     }
     await client.publish(error_topic, json.dumps(error_payload), retain=True)
 
-    ha_version = utils.get_ha_core_version()
+    ha_version = await utils.get_ha_core_version()
     ha_version_tuple = utils.parse_ha_version(ha_version)
 
     # Diagnostics

--- a/rootfs/usr/src/recovery.py
+++ b/rootfs/usr/src/recovery.py
@@ -33,7 +33,7 @@ class StateRecoverer:
         self.recovered_names = {}  # {id: name}
         self.context = context
 
-    def fetch_ha_state(self, entity_id: str) -> str | None:
+    async def fetch_ha_state(self, entity_id: str) -> str | None:
         """Fetch the current state of an entity from Home Assistant."""
         token = os.getenv("SUPERVISOR_TOKEN")
         if not token:
@@ -43,17 +43,22 @@ class StateRecoverer:
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=5) as response:
-                if response.status == 200:
-                    data = json.loads(response.read().decode())
-                    state = data.get("state")
-                    if state not in [None, "unknown", "unavailable"]:
-                        return state
+
+            def _fetch():
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        data = json.loads(response.read().decode())
+                        state = data.get("state")
+                        if state not in [None, "unknown", "unavailable"]:
+                            return state
+                return None
+
+            return await asyncio.to_thread(_fetch)
         except Exception as e:
             logger.debug(f"HA API state fetch for {entity_id} failed: {e}")
         return None
 
-    def fetch_all_ha_states(self) -> EntityStateList:
+    async def fetch_all_ha_states(self) -> EntityStateList:
         """Fetch all entity states from Home Assistant."""
         token = os.getenv("SUPERVISOR_TOKEN")
         if not token:
@@ -63,9 +68,14 @@ class StateRecoverer:
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=5) as response:
-                if response.status == 200:
-                    return json.loads(response.read().decode())
+
+            def _fetch():
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        return json.loads(response.read().decode())
+                return []
+
+            return await asyncio.to_thread(_fetch)
         except Exception as e:
             logger.debug(f"HA API fetch all states failed: {e}")
         return []
@@ -184,7 +194,7 @@ class StateRecoverer:
             if meter.total == 0:
                 if ha_states is None:
                     logger.info(f"Recovery: Meter {mid} not found on MQTT, attempting HA API fallback...")
-                    ha_states = await asyncio.to_thread(self.fetch_all_ha_states)
+                    ha_states = await self.fetch_all_ha_states()
 
                 found_val = self._find_total_in_ha(mid, ha_states)
                 if found_val is not None:

--- a/rootfs/usr/src/s0pcm_reader.py
+++ b/rootfs/usr/src/s0pcm_reader.py
@@ -28,7 +28,7 @@ async def main() -> None:
     # Initialize Context
     context = state_module.get_context()
 
-    version = get_version()
+    version = await get_version()
     context.s0pcm_reader_version = version
 
     config_path = Path("./")
@@ -37,7 +37,7 @@ async def main() -> None:
 
     try:
         # Load Configuration into context
-        context.config = config_module.read_config(version=context.s0pcm_reader_version, config_dir=config_path)
+        context.config = await config_module.read_config(version=context.s0pcm_reader_version, config_dir=config_path)
     except ValidationError, Exception:
         logger.error("Fatal exception during startup", exc_info=True)
         sys.exit(1)

--- a/rootfs/usr/src/serial_handler.py
+++ b/rootfs/usr/src/serial_handler.py
@@ -26,10 +26,10 @@ class SerialTaskState:
     started: bool = False
 
 
-def _log_available_ports() -> None:
+async def _log_available_ports() -> None:
     """Log available serial ports for debugging on connection failure."""
     try:
-        ports = serialx.list_serial_ports()
+        ports = await asyncio.to_thread(serialx.list_serial_ports)
         if ports:
             port_list = ", ".join(p.device for p in ports)
             logger.info(f"Available serial ports: {port_list}")
@@ -225,7 +225,7 @@ async def serial_task(context: state_module.AppContext) -> None:
                 task_state.serialerror += 1
                 context.set_error(f"Serialport connection failed: {type(e).__name__}: '{e}'", category="serial")
                 if task_state.serialerror == 1:
-                    _log_available_ports()
+                    await _log_available_ports()
                 logger.error(f"Retry in {context.config.serial.connect_retry} seconds")
                 await asyncio.sleep(context.config.serial.connect_retry)
     except asyncio.CancelledError:

--- a/rootfs/usr/src/utils.py
+++ b/rootfs/usr/src/utils.py
@@ -4,6 +4,7 @@ S0PCM Reader Utilities
 Helper functions for version detection and Home Assistant Supervisor API access.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 type JsonDict = dict[str, Any]
 
 
-def get_version() -> str:
+async def get_version() -> str:
     """
     Get the S0PCM Reader version.
 
@@ -49,19 +50,25 @@ def get_version() -> str:
         Path("./config.yaml"),
     ]
 
-    for path in search_paths:
-        if path.exists():
-            try:
-                with path.open() as f:
-                    if (config_yaml := yaml.safe_load(f)) and "version" in config_yaml:
-                        return f"{config_yaml['version']} (local)"
-            except OSError, yaml.YAMLError:
-                pass
+    def _read_version():
+        for path in search_paths:
+            if path.exists():
+                try:
+                    with path.open() as f:
+                        if (config_yaml := yaml.safe_load(f)) and "version" in config_yaml:
+                            return f"{config_yaml['version']} (local)"
+                except OSError, yaml.YAMLError:
+                    pass
+        return None
+
+    res = await asyncio.to_thread(_read_version)
+    if res:
+        return res
 
     return "dev"
 
 
-def get_supervisor_config(service: str) -> JsonDict:
+async def get_supervisor_config(service: str) -> JsonDict:
     """
     Fetch service configuration from the Home Assistant Supervisor API.
 
@@ -79,10 +86,15 @@ def get_supervisor_config(service: str) -> JsonDict:
     headers = {"Authorization": f"Bearer {token}"}
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=5) as response:
-            if response.status == 200:
-                data = json.loads(response.read().decode())
-                return data.get("data", {})
+
+        def _fetch():
+            with urllib.request.urlopen(req, timeout=5) as response:
+                if response.status == 200:
+                    data = json.loads(response.read().decode())
+                    return data.get("data", {})
+            return {}
+
+        return await asyncio.to_thread(_fetch)
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
         logger.debug(f"Supervisor API discovery for {service} failed: {e}")
     return {}
@@ -152,7 +164,7 @@ def parse_localized_number(value_str: str) -> float | None:
         return None
 
 
-def get_ha_core_version() -> str | None:
+async def get_ha_core_version() -> str | None:
     """Fetch the Home Assistant Core version from the Supervisor API."""
     token = os.getenv("SUPERVISOR_TOKEN")
     if not token:
@@ -162,10 +174,15 @@ def get_ha_core_version() -> str | None:
     headers = {"Authorization": f"Bearer {token}"}
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=5) as response:
-            if response.status == 200:
-                data = json.loads(response.read().decode())
-                return data.get("data", {}).get("version")
+
+        def _fetch():
+            with urllib.request.urlopen(req, timeout=5) as response:
+                if response.status == 200:
+                    data = json.loads(response.read().decode())
+                    return data.get("data", {}).get("version")
+            return None
+
+        return await asyncio.to_thread(_fetch)
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
         logger.debug(f"Supervisor API /core/info failed: {e}")
     return None

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -15,7 +15,7 @@ WORKDIR /workspace
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 # Install all deps (prod + test group)
 COPY pyproject.toml uv.lock ./

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -2,7 +2,7 @@
 # This container provides an isolated environment for running tests
 
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -4,7 +4,7 @@ WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --system --no-cache -r - && \

--- a/tests/standalone/simulator/Dockerfile
+++ b/tests/standalone/simulator/Dockerfile
@@ -1,4 +1,4 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 COPY tests/standalone/simulator/simulator.py /simulator.py
 CMD ["python3", "-u", "/simulator.py"]

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 # Use the project's lock file for paho-mqtt version consistency
 COPY pyproject.toml uv.lock ./

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 WORKDIR /app
 
 # Install uv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import json
 import os
 from pathlib import Path
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -21,18 +21,18 @@ def setup_config_test_env():
 
 
 class TestConfigLoading:
-    def test_load_default_config(self, mocker):
+    async def test_load_default_config(self, mocker):
         # Mock Path.exists and Path.read_text for safer modern python testing
         mocker.patch.object(Path, "exists", return_value=False)
         context = state_module.get_context()
-        context.config = config_module.read_config()
+        context.config = await config_module.read_config()
         assert context.config.mqtt.host == "127.0.0.1"
 
-    def test_load_config_from_options(self, sample_options, mocker):
+    async def test_load_config_from_options(self, sample_options, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         mocker.patch.object(Path, "read_text", return_value=json.dumps(sample_options))
         context = state_module.get_context()
-        context.config = config_module.read_config()
+        context.config = await config_module.read_config()
         assert context.config.mqtt.host == sample_options["mqtt"]["host"]
 
 
@@ -45,23 +45,23 @@ class TestCLI:
 
 
 class TestConfigEdgeCases:
-    def test_tls_path_join(self, mocker):
+    async def test_tls_path_join(self, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         mocker.patch.object(Path, "read_text", return_value=json.dumps({"security": {"tls": True, "tls_ca": "ca.crt"}}))
         context = state_module.get_context()
-        context.config = config_module.read_config(config_dir=Path("/data/"))
+        context.config = await config_module.read_config(config_dir=Path("/data/"))
         expected_path = os.path.normpath("data/ca.crt")
         actual_path = os.path.normpath(context.config.mqtt.tls_ca)
         assert expected_path in actual_path
 
-    def test_password_redaction(self, mocker):
+    async def test_password_redaction(self, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         # Test 1: Password set
         mocker.patch.object(
             Path, "read_text", return_value=json.dumps({"mqtt": {"password": "secret", "username": "admin"}})
         )
         with patch("logging.Logger.debug") as mock_debug:
-            config_module.read_config()
+            await config_module.read_config()
             log_str = str(mock_debug.call_args[0][0])
             assert "**********" in log_str
             assert "secret" not in log_str
@@ -70,7 +70,7 @@ class TestConfigEdgeCases:
         # Test 2: Password None
         mocker.patch.object(Path, "read_text", return_value=json.dumps({}))
         with patch("logging.Logger.debug") as mock_debug:
-            config_module.read_config()
+            await config_module.read_config()
             log_str = str(mock_debug.call_args[0][0])
             # Check for None explicitly
             assert "'password': None" in log_str
@@ -97,71 +97,71 @@ class TestErrorHandling:
 
 
 class TestConfigCoverage:
-    def test_read_config_options_exception(self):
+    async def test_read_config_options_exception(self):
         """Test exception handling during options.json load (lines 118-119)."""
         with (
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.read_text", side_effect=Exception("Read Error")),
             patch("config.logger.error") as mock_logger,
         ):
-            config_module.read_config()
+            await config_module.read_config()
             assert mock_logger.called
             assert any("Failed to load" in str(c) for c in mock_logger.call_args_list)
 
-    def test_read_config_mqtt_discovery_log(self, mocker):
+    async def test_read_config_mqtt_discovery_log(self, mocker):
         """Test logging when MQTT service discovery is used (line 126)."""
         # Mock get_supervisor_config to return data
         with (
-            patch("config.get_supervisor_config", return_value={"host": "1.2.3.4"}),
+            patch("config.get_supervisor_config", new_callable=AsyncMock, return_value={"host": "1.2.3.4"}),
             patch("config.logger.info") as mock_logger,
         ):
-            config_module.read_config()
+            await config_module.read_config()
 
             # One of the calls should be the discovery message
             found = any("Using MQTT service discovery" in str(c) for c in mock_logger.call_args_list)
             assert found
 
-    def test_read_config_returns_model(self):
+    async def test_read_config_returns_model(self):
         """Test that read_config returns a ConfigModel directly."""
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.mqtt.base_topic == "s0pcmreader"
         assert model.log.level == "INFO"
 
-    def test_read_config_mqtt_version_string(self):
+    async def test_read_config_mqtt_version_string(self):
         """Test that MQTT version is stored as a string."""
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.mqtt.version == "5.0"
         assert isinstance(model.mqtt.version, str)
 
 
 class TestAutoDetectSerialPort:
-    def test_auto_detect_no_ports(self, mocker):
+    async def test_auto_detect_no_ports(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         with patch("config.logger.warning") as mock_warn:
-            port = config_module._auto_detect_serial_port()
+            port = await config_module._auto_detect_serial_port()
             assert port == "/dev/ttyACM0"
             mock_warn.assert_called_once()
             assert "No serial ports detected" in mock_warn.call_args[0][0]
 
-    def test_auto_detect_ch340_vid(self, mocker):
+    async def test_auto_detect_ch340_vid(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/ttyUSB99"
         mock_port.vid = 0x1A86
         mock_port.manufacturer = "CH340 Manufacturer"
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/ttyUSB99"
 
-    def test_auto_detect_ch340_name(self, mocker):
+    async def test_auto_detect_ch340_name(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
         mock_port.vid = 0x1234
         mock_port.manufacturer = None
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
 
-    def test_auto_detect_generic_usb(self, mocker):
+    async def test_auto_detect_generic_usb(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
         mock_port.vid = 0x0403
@@ -169,10 +169,10 @@ class TestAutoDetectSerialPort:
         mock_port.description = "FTDI USB Serial"
 
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
 
-    def test_auto_detect_fallback_first(self, mocker):
+    async def test_auto_detect_fallback_first(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/ttyS0"
         mock_port.vid = None
@@ -180,31 +180,31 @@ class TestAutoDetectSerialPort:
         mock_port.description = "Standard Serial Port"
 
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/ttyS0"
 
-    def test_auto_detect_exception(self, mocker):
+    async def test_auto_detect_exception(self, mocker):
         mocker.patch("serialx.list_serial_ports", side_effect=RuntimeError("Scan error"))
         with patch("config.logger.error") as mock_error:
-            port = config_module._auto_detect_serial_port()
+            port = await config_module._auto_detect_serial_port()
             assert port == "/dev/ttyACM0"
             mock_error.assert_called_once()
             assert "Exception during port scan" in mock_error.call_args[0][0]
 
-    def test_read_config_triggers_auto_detect(self, mocker):
+    async def test_read_config_triggers_auto_detect(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         mocker.patch("pathlib.Path.exists", return_value=True)
         mocker.patch("pathlib.Path.read_text", return_value=json.dumps({"device": None}))
 
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
-    def test_read_config_triggers_auto_detect_missing_key(self, mocker):
+    async def test_read_config_triggers_auto_detect_missing_key(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         mocker.patch("pathlib.Path.exists", return_value=True)
         mocker.patch("pathlib.Path.read_text", return_value=json.dumps({}))
 
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -20,7 +20,7 @@ async def test_send_global_discovery_new_ha(mocker):
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
-    mocker.patch("utils.get_ha_core_version", return_value="2025.5.0")
+    mocker.patch("utils.get_ha_core_version", new_callable=AsyncMock, return_value="2025.5.0")
 
     await discovery.send_global_discovery(mock_client, context)
 
@@ -55,7 +55,7 @@ async def test_send_global_discovery_old_ha(mocker):
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
-    mocker.patch("utils.get_ha_core_version", return_value="2024.12.0")
+    mocker.patch("utils.get_ha_core_version", new_callable=AsyncMock, return_value="2024.12.0")
 
     await discovery.send_global_discovery(mock_client, context)
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -125,7 +125,7 @@ class TestMQTTMessageParsing:
 class TestHAAPIFallback:
     """Test Home Assistant API fallback methods."""
 
-    def test_fetch_ha_state_success(self, recoverer, mocker):
+    async def test_fetch_ha_state_success(self, recoverer, mocker):
         """Test successful HA API state fetch."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -139,19 +139,19 @@ class TestHAAPIFallback:
 
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result == "1234567"
 
-    def test_fetch_ha_state_no_token(self, recoverer, mocker):
+    async def test_fetch_ha_state_no_token(self, recoverer, mocker):
         """Test HA API fetch returns None when no token available."""
         mocker.patch.dict("os.environ", {}, clear=True)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result is None
 
-    def test_fetch_ha_state_unknown_state(self, recoverer, mocker):
+    async def test_fetch_ha_state_unknown_state(self, recoverer, mocker):
         """Test HA API fetch returns None for unknown/unavailable states."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
         mock_response = MagicMock()
@@ -163,11 +163,23 @@ class TestHAAPIFallback:
         mock_response.__exit__ = lambda self, *args: None
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result is None
 
-    def test_fetch_all_ha_states_success(self, recoverer, mocker):
+    async def test_fetch_ha_state_status_not_200(self, recoverer, mocker):
+        """Test fetch HA state returns None when response status is not 200."""
+        mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
+        mock_response = MagicMock()
+        mock_response.status = 204
+        mock_response.__enter__ = lambda self: self
+        mock_response.__exit__ = lambda self, *args: None
+        mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        assert result is None
+
+    async def test_fetch_all_ha_states_success(self, recoverer, mocker):
         """Test successful fetch of all HA states."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -184,18 +196,30 @@ class TestHAAPIFallback:
 
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_all_ha_states()
+        result = await recoverer.fetch_all_ha_states()
 
         assert len(result) == 2
         assert result[0]["entity_id"] == "sensor.s0pcmreader_1_total"
         assert result[1]["state"] == "5000"
 
-    def test_fetch_all_ha_states_no_token(self, recoverer, mocker):
+    async def test_fetch_all_ha_states_no_token(self, recoverer, mocker):
         """Test fetch all states returns empty list when no token."""
         mocker.patch.dict("os.environ", {}, clear=True)
 
-        result = recoverer.fetch_all_ha_states()
+        result = await recoverer.fetch_all_ha_states()
 
+        assert result == []
+
+    async def test_fetch_all_ha_states_status_not_200(self, recoverer, mocker):
+        """Test fetch all states returns empty list when response status is not 200."""
+        mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
+        mock_response = MagicMock()
+        mock_response.status = 204
+        mock_response.__enter__ = lambda self: self
+        mock_response.__exit__ = lambda self, *args: None
+        mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+        result = await recoverer.fetch_all_ha_states()
         assert result == []
 
 
@@ -410,6 +434,7 @@ class TestRecoveryFlow:
         mocker.patch.object(
             recoverer,
             "fetch_all_ha_states",
+            new_callable=AsyncMock,
             return_value=[{"entity_id": "sensor.s0pcmreader_1_total", "state": "5000"}],
         )
 
@@ -428,22 +453,22 @@ class TestRecoveryFlow:
 
 
 class TestRecoveryExceptions:
-    def test_fetch_ha_state_exception(self, recoverer):
+    async def test_fetch_ha_state_exception(self, recoverer):
         """Test fetch_ha_state exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
         ):
-            res = recoverer.fetch_ha_state("sensor.test")
+            res = await recoverer.fetch_ha_state("sensor.test")
             assert res is None
 
-    def test_fetch_all_ha_states_exception(self, recoverer):
+    async def test_fetch_all_ha_states_exception(self, recoverer):
         """Test fetch_all_ha_states exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
         ):
-            res = recoverer.fetch_all_ha_states()
+            res = await recoverer.fetch_all_ha_states()
             assert res == []
 
     async def test_run_recover_named_meter_gap(self, recoverer):

--- a/tests/test_s0pcm_reader.py
+++ b/tests/test_s0pcm_reader.py
@@ -12,7 +12,8 @@ async def test_main_initialization(mocker):
     """Test that main() initializes config and starts tasks."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
 
     # Mock serial_task and mqtt_task as async functions
     mock_serial_task = mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
@@ -23,9 +24,7 @@ async def test_main_initialization(mocker):
     await s0pcm_reader.main()
 
     # Verify read_config was called
-    import config as config_module_imp
-
-    config_module_imp.read_config.assert_called_once()
+    s0pcm_reader.config_module.read_config.assert_called_once()
 
     # Verify tasks were started (called as coroutines in TaskGroup)
     mock_serial_task.assert_called_once()
@@ -36,7 +35,10 @@ async def test_main_config_exception_exit(mocker):
     """Test main exit on config exception."""
     import s0pcm_reader
 
-    mocker.patch("s0pcm_reader.config_module.read_config", side_effect=Exception("Config Error"))
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch(
+        "s0pcm_reader.config_module.read_config", new_callable=AsyncMock, side_effect=Exception("Config Error")
+    )
     mocker.patch("s0pcm_reader.logger")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -59,7 +61,8 @@ async def test_main_signal_handler(mocker):
     """Test signal handler registration and execution."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.mqtt_task", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.logger")
@@ -89,7 +92,8 @@ async def test_main_cancellation_handling(mocker):
     """Test that main() handles CancelledError ExceptionGroup gracefully."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.logger")
 
     # Mock TaskGroup to raise BaseExceptionGroup containing CancelledError

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -22,11 +22,11 @@ import state as state_module
 
 
 @pytest.fixture(autouse=True)
-def setup_serial_test_state():
+async def setup_serial_test_state():
     """Ensure a clean state for every test."""
     context = state_module.get_context()
     # Initialize basic config using standard logic
-    context.config = config_module.read_config(version="test")
+    context.config = await config_module.read_config(version="test")
     context.s0pcm_firmware = "Unknown"
     context.state.reset_state()
     context.lasterror_serial = None
@@ -41,7 +41,7 @@ def s0pcm_packets():
 
 
 class TestSerialPacketParsing:
-    def test_handle_data_packet_updates_measurement(self, s0pcm_packets, mocker):
+    async def test_handle_data_packet_updates_measurement(self, s0pcm_packets, mocker):
         context = state_module.get_context()
         mocker.patch.object(context, "set_error")
 
@@ -51,7 +51,7 @@ class TestSerialPacketParsing:
         assert 1 in context.state.meters
         assert context.state.meters[1].total == 100
 
-    def test_invalid_packet_sets_error(self, s0pcm_packets, mocker):
+    async def test_invalid_packet_sets_error(self, s0pcm_packets, mocker):
         context = state_module.get_context()
         mock_set_error = mocker.patch.object(context, "set_error")
         _handle_data_packet(context, "ID:8237:I:10:M1:0:100")  # Too short
@@ -59,7 +59,7 @@ class TestSerialPacketParsing:
 
 
 class TestPulseCountLogic:
-    def test_pulse_increment(self):
+    async def test_pulse_increment(self):
         # Initialize meter properly using state_module models
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
@@ -67,14 +67,14 @@ class TestPulseCountLogic:
         assert context.state.meters[1].total == 1010
         assert context.state.meters[1].today == 60
 
-    def test_pulse_reset_detection(self):
+    async def test_pulse_reset_detection(self):
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
         _update_meter(context, 1, 10, 10, 20)  # Restarted (pulsecount reset to 10)
         # Total should increase by 10
         assert context.state.meters[1].total == 1010
 
-    def test_pulse_anomaly(self):
+    async def test_pulse_anomaly(self):
         """Test pulsecount anomaly (lower but not 0)."""
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000)
@@ -85,7 +85,7 @@ class TestPulseCountLogic:
         # Logic: delta = pulsecount (90). Total += 90.
         assert context.state.meters[1].total == 1090
 
-    def test_update_meter_uninitialized(self):
+    async def test_update_meter_uninitialized(self):
         context = state_module.AppContext()
         _update_meter(context, 1, 5, 5, 10)
         assert 1 in context.state.meters
@@ -93,7 +93,7 @@ class TestPulseCountLogic:
 
 
 class TestSerialPacketAdvanced:
-    def test_handle_header_parsing(self):
+    async def test_handle_header_parsing(self):
         context = state_module.get_context()
 
         _handle_header(context, "/8237:S0 Pulse Counter V0.6")
@@ -140,7 +140,7 @@ class TestSerialPacketAdvanced:
 
 
 class TestDayChange:
-    def test_day_change_resets_today(self):
+    async def test_day_change_resets_today(self):
         context = state_module.get_context()
         yesterday = datetime.date.today() - datetime.timedelta(days=1)
         # Set date in state
@@ -154,7 +154,7 @@ class TestDayChange:
         assert context.state.date == datetime.date.today()
 
 
-def test_handle_header_fallback():
+async def test_handle_header_fallback():
     """Test _handle_header fallback paths."""
     context = state_module.get_context()
 
@@ -179,7 +179,7 @@ def test_handle_header_fallback():
     assert context.s0pcm_firmware == bad_str
 
 
-def test_update_meter_reset_logging():
+async def test_update_meter_reset_logging():
     """Test _update_meter reset logging."""
     context = state_module.get_context()
     context.state.meters[1] = state_module.MeterState(total=1000, pulsecount=500)
@@ -302,7 +302,7 @@ async def test_serial_task_exclusive_mode(mocker):
     assert kwargs["exclusive"] is True
 
 
-def test_log_available_ports_with_ports():
+async def test_log_available_ports_with_ports():
     """Test _log_available_ports when ports are detected."""
     mock_port = MagicMock()
     mock_port.device = "/dev/ttyACM0"
@@ -310,28 +310,28 @@ def test_log_available_ports_with_ports():
         patch("serialx.list_serial_ports", return_value=[mock_port]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert any("/dev/ttyACM0" in str(c) for c in mock_logger.info.call_args_list)
 
 
-def test_log_available_ports_no_ports():
+async def test_log_available_ports_no_ports():
     """Test _log_available_ports when no ports are detected."""
     with (
         patch("serialx.list_serial_ports", return_value=[]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert mock_logger.warning.called
         assert "No serial ports detected" in mock_logger.warning.call_args[0][0]
 
 
-def test_log_available_ports_exception():
+async def test_log_available_ports_exception():
     """Test _log_available_ports handles exceptions gracefully."""
     with (
         patch("serialx.list_serial_ports", side_effect=OSError("Permission denied")),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert mock_logger.debug.called
         assert "Unable to enumerate" in mock_logger.debug.call_args[0][0]
 
@@ -353,7 +353,7 @@ async def test_log_available_ports_called_on_first_failure(mocker):
 
     mocker.patch("serialx.async_serial_for_url", side_effect=fail_then_cancel)
     mocker.patch("asyncio.sleep", return_value=None)
-    mock_log_ports = mocker.patch("serial_handler._log_available_ports")
+    mock_log_ports = mocker.patch("serial_handler._log_available_ports", new_callable=AsyncMock)
 
     # serial_task catches CancelledError internally and returns
     await serial_task(context)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,22 +12,22 @@ import pytest
 import utils
 
 
-def test_get_version_from_env(mocker):
+async def test_get_version_from_env(mocker):
     """Test get_version from environment variable."""
     mocker.patch.dict(os.environ, {"S0PCM_READER_VERSION": "3.1.0"})
-    assert utils.get_version() == "3.1.0"
+    assert await utils.get_version() == "3.1.0"
 
 
-def test_get_version_fallback(mocker, tmp_path, monkeypatch):
+async def test_get_version_fallback(mocker, tmp_path, monkeypatch):
     """Test GetVersion fallback when env is missing and no config file."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
     # Mock __file__ to point to our tmp_path
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
+async def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
     """Test GetVersion reading from config.yaml."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -38,11 +38,11 @@ def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
     # Mock __file__ so utils looks in tmp_path
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
-    version = utils.get_version()
+    version = await utils.get_version()
     assert "3.0.0-test" in version
 
 
-def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
+async def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
     """Test get_version handles invalid YAML gracefully."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -53,10 +53,10 @@ def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
     # Should fall back to 'dev' because our file is invalid
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
+async def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
     """Test get_version when YAML exists but has no version key."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -66,16 +66,16 @@ def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
 
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_supervisor_config_no_token(mocker):
+async def test_get_supervisor_config_no_token(mocker):
     """Test GetSupervisorConfig when token is missing."""
     mocker.patch.dict(os.environ, {}, clear=True)
-    assert utils.get_supervisor_config("mqtt") == {}
+    assert await utils.get_supervisor_config("mqtt") == {}
 
 
-def test_get_supervisor_config_success(mocker):
+async def test_get_supervisor_config_success(mocker):
     """Test successful Supervisor API config fetch."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -89,21 +89,34 @@ def test_get_supervisor_config_success(mocker):
 
     mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-    result = utils.get_supervisor_config("mqtt")
+    result = await utils.get_supervisor_config("mqtt")
 
     assert result["host"] == "core-mosquitto"
     assert result["port"] == 1883
     assert result["username"] == "mqtt_user"
 
 
-def test_get_supervisor_config_api_error(mocker):
+async def test_get_supervisor_config_api_error(mocker):
     """Test Supervisor API handles errors gracefully."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     # Raise URLError which is one of the caught exceptions
     mocker.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("API Error"))
 
-    result = utils.get_supervisor_config("mqtt")
+    result = await utils.get_supervisor_config("mqtt")
 
+    assert result == {}
+
+
+async def test_get_supervisor_config_status_not_200(mocker):
+    """Test Supervisor API returns empty dict when response status is not 200."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mock_response = MagicMock()
+    mock_response.status = 204
+    mock_response.__enter__ = lambda self: self
+    mock_response.__exit__ = lambda self, *args: None
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    result = await utils.get_supervisor_config("mqtt")
     assert result == {}
 
 
@@ -112,13 +125,13 @@ def test_get_supervisor_config_api_error(mocker):
 # ------------------------------------------------------------------------------------
 
 
-def test_get_ha_core_version_no_token(mocker):
+async def test_get_ha_core_version_no_token(mocker):
     """Test get_ha_core_version when token is missing."""
     mocker.patch.dict(os.environ, {}, clear=True)
-    assert utils.get_ha_core_version() is None
+    assert await utils.get_ha_core_version() is None
 
 
-def test_get_ha_core_version_success(mocker):
+async def test_get_ha_core_version_success(mocker):
     """Test successful HA core version fetch."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     mock_response = MagicMock()
@@ -128,14 +141,26 @@ def test_get_ha_core_version_success(mocker):
     mock_response.__exit__ = lambda self, *args: None
     mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-    assert utils.get_ha_core_version() == "2025.5.0"
+    assert await utils.get_ha_core_version() == "2025.5.0"
 
 
-def test_get_ha_core_version_error(mocker):
+async def test_get_ha_core_version_error(mocker):
     """Test get_ha_core_version handles errors gracefully."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     mocker.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("API Error"))
-    assert utils.get_ha_core_version() is None
+    assert await utils.get_ha_core_version() is None
+
+
+async def test_get_ha_core_version_status_not_200(mocker):
+    """Test get_ha_core_version returns None when response status is not 200."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mock_response = MagicMock()
+    mock_response.status = 204
+    mock_response.__enter__ = lambda self: self
+    mock_response.__exit__ = lambda self, *args: None
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    assert await utils.get_ha_core_version() is None
 
 
 def test_parse_ha_version():


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b5.

### Changes in this release:
- chore(deps): update python:3.14-alpine docker digest to 003970a (#300)
- chore(deps): update ghcr.io/astral-sh/uv docker digest to ff07b86 (#299)

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Fixed
- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
