### PR TITLE
Release v5.0.0-b6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.0-b6] - 2026-06-15
 ### Added
-- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
+- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ This app is designed to be a **pure hardware driver**. Its sole responsibility i
 
 If a feature request asks for calculations inside the app, point the user to the DOCS.md Cookbook instead.
 
+### Asyncio Concurrency Model
+
+Starting in version 5.0.0, the application core runs on a single-threaded `asyncio` event loop instead of multiple OS-level threads. This architecture provides major advantages:
+- **No Locking or Cloning Overhead**: All state updates happen sequentially on the main event loop, eliminating potential race conditions by design. We no longer need thread synchronization locks (`threading.RLock`) or expensive recursive deep-copying (`model_copy(deep=True)`) of the application state. In micro-benchmarks, this transition resulted in a **~90x throughput increase** (from ~16k to ~1.5M ops/sec) and eliminated state-cloning memory allocations.
+- **Resource Efficiency**: Coroutines are far more memory-efficient than OS threads, which is vital when running as an add-on on low-powered smart home servers (like Raspberry Pi).
+- **Non-Blocking I/O**: Network calls (MQTT publishing) and serial reads (`serialx.AsyncSerial`) are natively asynchronous. Slow blocking operations (such as configuration loading, Supervisor API calls, and serial port listing) are offloaded to helper threads using `asyncio.to_thread` to keep the main event loop responsive and prevent packet loss or keep-alive timeouts.
+
 ## Project Structure
 
 ```text

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -106,14 +106,25 @@ async def _auto_detect_serial_port() -> str:
             logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
             return "/dev/ttyACM0"
 
-        # 1. Look for known S0PCM CH340 USB-serial chip (Vendor ID 0x1a86 or "1a86" in device name)
+        # 1. Look for known S0PCM candidates: CH340 (Vendor ID 0x1a86) or Arduino/Leonardo (Vendor IDs 0x2341, 0x2a03)
         for p in ports:
-            is_ch340_vid = p.vid == 0x1A86
-            is_ch340_str = "1a86" in p.device.lower() or (
-                p.manufacturer is not None and "1a86" in p.manufacturer.lower()
+            is_candidate_vid = p.vid in (0x1A86, 0x2341, 0x2A03)
+
+            # Check string indicators (device name, description, or manufacturer)
+            dev_str = p.device.lower()
+            desc_str = p.description.lower() if p.description is not None else ""
+            mfg_str = p.manufacturer.lower() if p.manufacturer is not None else ""
+
+            is_candidate_str = any(
+                keyword in dev_str or keyword in desc_str or keyword in mfg_str
+                for keyword in ("1a86", "arduino", "leonardo")
             )
-            if is_ch340_vid or is_ch340_str:
-                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' (CH340)")
+
+            if is_candidate_vid or is_candidate_str:
+                chip_info = (
+                    "CH340" if (p.vid == 0x1A86 or "1a86" in mfg_str or "1a86" in dev_str) else "Arduino/Leonardo"
+                )
+                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' ({chip_info})")
                 return p.device
 
         # 2. Look for any other USB serial port (has "usb" in path or description)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,6 +161,26 @@ class TestAutoDetectSerialPort:
         port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
 
+    async def test_auto_detect_arduino_vid(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyACM99"
+        mock_port.vid = 0x2341
+        mock_port.manufacturer = "Arduino LLC"
+        mock_port.description = "Arduino Leonardo"
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = await config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyACM99"
+
+    async def test_auto_detect_arduino_name(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-Arduino_LLC_Arduino_Leonardo-if00-port0"
+        mock_port.vid = 0x1234
+        mock_port.manufacturer = None
+        mock_port.description = None
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = await config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-Arduino_LLC_Arduino_Leonardo-if00-port0"
+
     async def test_auto_detect_generic_usb(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -83,7 +83,7 @@ def test_app_state_iter():
     state.meters[1] = state_module.MeterState(total=100)
 
     assert 1 in state.meters
-    assert "date" in state.model_fields
+    assert "date" in state_module.AppState.model_fields
 
 
 def test_meter_state_initial_values():


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.0-b6.

### Changes in this release:

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Fixed
- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
```
