### PR TITLE
Release v5.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -438,8 +438,8 @@ jobs:
           cd main-repo
           
           # Setup git config
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
           
           git remote rm origin || true
           git add config.yaml repository.yaml build.yaml README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0-b0] - 2026-06-13
+### Security
+- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
+- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
+- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.
+
+### Changed
+- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
+- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
+- **Dependencies**: Dependency updates.
+
 ## [4.3.4] - 2026-06-13
 ### Changed
 - **Dependencies**: Dependency updates (serialx v1.8.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b1] - 2026-06-14
+## [5.0.0-b2] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b2] - 2026-06-14
+## [5.0.0-b3] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b6] - 2026-06-15
+## [5.0.0-b7] - 2026-06-15
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
 - **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
-- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
+- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies (including `serialx` to 1.8.2).
 
 ## [4.3.4] - 2026-06-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b5] - 2026-06-14
+## [5.0.0-b6] - 2026-06-15
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.0.0-b6] - 2026-06-15
 ### Added
-- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
+- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.0-b1] - 2026-06-13
+## [5.0.0-b0] - 2026-06-14
+### Added
+- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
+- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
+
 ### Security
 - **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
 - **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
@@ -13,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
 - **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
-- **Dependencies**: Dependency updates.
+- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies.
 
 ## [4.3.4] - 2026-06-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b3] - 2026-06-14
+## [5.0.0-b4] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b0] - 2026-06-14
+## [5.0.0-b1] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b7] - 2026-06-15
+## [5.0.0-b8] - 2026-06-16
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.4] - 2026-06-13
 ### Changed
-- **Dependencies**: Dependency updates (serialx v1.8.1).
+- **Dependencies**: Dependency updates (serialx v1.8.2).
 
 ## [4.3.3] - 2026-05-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.0-b0] - 2026-06-13
+## [4.4.0-b1] - 2026-06-13
 ### Security
 - **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
 - **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 
+### Fixed
+- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
+- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.
+
 ### Security
 - **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
 - **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.0-b2] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
+- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
 - **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b8] - 2026-06-16
+## [5.0.0] - 2026-06-16
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0-b4] - 2026-06-14
+## [5.0.0-b5] - 2026-06-14
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization.
 - **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ This app is designed to be a **pure hardware driver**. Its sole responsibility i
 
 If a feature request asks for calculations inside the app, point the user to the DOCS.md Cookbook instead.
 
+### Asyncio Concurrency Model
+
+Starting in version 5.0.0, the application core runs on a single-threaded `asyncio` event loop instead of multiple OS-level threads. This architecture provides major advantages:
+- **No Locking or Cloning Overhead**: All state updates happen sequentially on the main event loop, eliminating potential race conditions by design. We no longer need thread synchronization locks (`threading.RLock`) or expensive recursive deep-copying (`model_copy(deep=True)`) of the application state. In micro-benchmarks, this transition resulted in a **~90x throughput increase** (from ~16k to ~1.5M ops/sec) and eliminated state-cloning memory allocations.
+- **Resource Efficiency**: Coroutines are far more memory-efficient than OS threads, which is vital when running as an add-on on low-powered smart home servers (like Raspberry Pi).
+- **Non-Blocking I/O**: Network calls (MQTT publishing) and serial reads (`serialx.AsyncSerial`) are natively asynchronous. Slow blocking operations (such as configuration loading, Supervisor API calls, and serial port listing) are offloaded to helper threads using `asyncio.to_thread` to keep the main event loop responsive and prevent packet loss or keep-alive timeouts.
+
 ## Project Structure
 
 ```text

--- a/DOCS.md
+++ b/DOCS.md
@@ -160,7 +160,7 @@ The app uses a dual-layer recovery system:
 **Note**: If you wipe both MQTT and restart HA simultaneously, data may be lost. **Always backup your MQTT broker.**
 
 ## 8. Technical Details
-- **Architecture**: Multithreaded Python app.
+- **Architecture**: Asynchronous Python application running on a single-threaded asyncio event loop.
 - **Discovery**: Follows Home Assistant MQTT Discovery standard.
 - **Topics**:
     - Data: `s0pcmreader/<ID>/total`

--- a/DOCS.md
+++ b/DOCS.md
@@ -45,7 +45,7 @@ services:
 ## 3. Configuration
 
 ### General Options
-- **Device**: Path to the USB device (e.g., `/dev/ttyACM0`).
+- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left blank or set to `null` (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip).
 - **Log Level**: (Default: `info`) Set logging verbosity (`debug`, `info`, `warning`, `error`, `critical`).
 
 ### Connection Settings

--- a/DOCS.md
+++ b/DOCS.md
@@ -9,8 +9,7 @@ This application reads pulse counts from S0PCM-2 (2-channel) or S0PCM-5 (5-chann
 ### Home Assistant App (Recommended)
 1. Add the repository: `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader`
 2. Install **S0PCM Reader** from the App Store.
-3. Configure the **Device** (e.g., `/dev/ttyACM0`) in the Configuration tab.
-4. Start the app.
+3. Start the app. By default, it will auto-detect your connected S0PCM reader. (Optional: To manually select a port, enable "Show unused optional configuration options" in the Configuration tab).
 
 ### Standalone Docker Container (Advanced)
 If you are not using Home Assistant OS/Supervisor, you can run this as a standalone container.
@@ -45,7 +44,7 @@ services:
 ## 3. Configuration
 
 ### General Options
-- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left blank or set to `null` (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip).
+- **Device**: (Optional) Path to the USB device (e.g., `/dev/ttyACM0`). If left unconfigured (default), the app will automatically scan and select the connected S0PCM reader (CH340 chip). In the Home Assistant UI, this field is hidden under the "Show unused optional configuration options" toggle by default.
 - **Log Level**: (Default: `info`) Set logging verbosity (`debug`, `info`, `warning`, `error`, `critical`).
 
 ### Connection Settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 
 LABEL org.opencontainers.image.title="S0PCM Reader (Standalone)" \
       org.opencontainers.image.description="Standalone S0PCM reader for non-Home Assistant environments" \

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ An easy-to-use Home Assistant App that reads pulse counters from an **S0PCM-2** 
 1. Add this repository to your Home Assistant App Store:
    `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader`
 2. Search for **S0PCM Reader** and click **Install**.
-3. Navigate to the **Configuration** tab.
-4. Select your **S0PCM USB device** (e.g., `/dev/ttyACM0`).
-5. **Start** the app.
+3. **Start** the app. By default, it will auto-detect your connected S0PCM USB device. (Optional: To customize settings or manually configure the port, open the **Configuration** tab).
 
 ### Beta version
 If you want to help test upcoming features, you can install the Beta version. You can install both the Beta and Stable versions at the same time without conflicts.
@@ -39,7 +37,7 @@ If you want to help test upcoming features, you can install the Beta version. Yo
    `https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader-beta`
 2. Search for **S0PCM Reader (Beta)** and click **Install**.
 3. Go to your Stable **S0PCM Reader**, **Stop** it, and disable **Start on boot**.
-4. Go to **S0PCM Reader (Beta)**, configure your USB device, and **Start** it.
+4. Go to **S0PCM Reader (Beta)** and click **Start** (it will auto-detect your USB device by default).
 
 ## 📖 Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Only the latest version of the app is supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | Latest  | :white_check_mark: |
-| < 4.0.0 | :x:                |
+| < 5.0.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b3"
+version: "5.0.0-b4"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.4.0-b1"
+version: "5.0.0-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b6"
+version: "5.0.0-b7"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b0"
+version: "5.0.0-b1"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b1"
+version: "5.0.0-b2"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.4.0-b0"
+version: "4.4.0-b1"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ options:
     tls_port: 8883
   log_level: info
 schema:
-  device: device(subsystem=tty)
+  device: device(subsystem=tty)?
   mqtt:
     host: str?
     port: port?

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "4.3.4"
+version: "4.4.0-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b4"
+version: "5.0.0-b5"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b8"
+version: "5.0.0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,8 @@ init: false
 startup: application
 hassio_api: true
 homeassistant_api: true
+uart: true
 options:
-  device: null
   mqtt:
     base_topic: "s0pcmreader"
     protocol: "5.0"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b2"
+version: "5.0.0-b3"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b7"
+version: "5.0.0-b8"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.0-b5"
+version: "5.0.0-b6"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.3.4"
+version = "4.4.0-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b8"
+version = "5.0.0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b7"
+version = "5.0.0-b8"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b5"
+version = "5.0.0-b6"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b2"
+version = "5.0.0-b3"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b6"
+version = "5.0.0-b7"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b0"
+version = "5.0.0-b1"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [
     "pyyaml==6.0.3",
-    "serialx==1.8.1",
+    "serialx==1.8.2",
     "aiomqtt>=2.5.1",
     "pydantic==2.13.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b4"
+version = "5.0.0-b5"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b1"
+version = "5.0.0-b2"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "s0pcm-reader"
-version = "4.4.0-b1"
+version = "5.0.0-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [
     "pyyaml==6.0.3",
     "serialx==1.8.1",
-    "paho-mqtt==2.1.0",
+    "aiomqtt>=2.5.1",
     "pydantic==2.13.4",
 ]
 
@@ -16,6 +16,7 @@ test = [
     "pytest-mock>=3.15.1",
     "pytest-cov>=7.0.0",
     "pytest-timeout>=2.4.0",
+    "pytest-asyncio>=1.0.0",
     "ruff>=0.15.4",
 ]
 
@@ -60,6 +61,7 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 addopts = "-v --tb=short --strict-markers --disable-warnings -p no:cacheprovider"
+asyncio_mode = "auto"
 pythonpath = [
     "rootfs/usr/src",
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.0-b3"
+version = "5.0.0-b4"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "4.4.0-b0"
+version = "4.4.0-b1"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -106,14 +106,25 @@ async def _auto_detect_serial_port() -> str:
             logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
             return "/dev/ttyACM0"
 
-        # 1. Look for known S0PCM CH340 USB-serial chip (Vendor ID 0x1a86 or "1a86" in device name)
+        # 1. Look for known S0PCM candidates: CH340 (Vendor ID 0x1a86) or Arduino/Leonardo (Vendor IDs 0x2341, 0x2a03)
         for p in ports:
-            is_ch340_vid = p.vid == 0x1A86
-            is_ch340_str = "1a86" in p.device.lower() or (
-                p.manufacturer is not None and "1a86" in p.manufacturer.lower()
+            is_candidate_vid = p.vid in (0x1A86, 0x2341, 0x2A03)
+
+            # Check string indicators (device name, description, or manufacturer)
+            dev_str = p.device.lower()
+            desc_str = p.description.lower() if p.description is not None else ""
+            mfg_str = p.manufacturer.lower() if p.manufacturer is not None else ""
+
+            is_candidate_str = any(
+                keyword in dev_str or keyword in desc_str or keyword in mfg_str
+                for keyword in ("1a86", "arduino", "leonardo")
             )
-            if is_ch340_vid or is_ch340_str:
-                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' (CH340)")
+
+            if is_candidate_vid or is_candidate_str:
+                chip_info = (
+                    "CH340" if (p.vid == 0x1A86 or "1a86" in mfg_str or "1a86" in dev_str) else "Arduino/Leonardo"
+                )
+                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' ({chip_info})")
                 return p.device
 
         # 2. Look for any other USB serial port (has "usb" in path or description)

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -39,7 +39,7 @@ class SerialConfig(BaseModel):
     parity: serialx.Parity = serialx.PARITY_EVEN
     stopbits: serialx.StopBits = serialx.STOPBITS_ONE
     bytesize: int = serialx.SEVENBITS
-    timeout: float | None = None
+    timeout: float | None = 30.0
     connect_retry: int = 5
 
 

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -93,6 +93,43 @@ def init_args() -> Path:
     return config_path
 
 
+def _auto_detect_serial_port() -> str:
+    """
+    Auto-detect the S0PCM serial port on the system.
+
+    Looks for typical CH340 USB-serial chips first, then any USB-serial device.
+    """
+    try:
+        ports = serialx.list_serial_ports()
+        if not ports:
+            logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
+            return "/dev/ttyACM0"
+
+        # 1. Look for known S0PCM CH340 USB-serial chip (Vendor ID 0x1a86 or "1a86" in device name)
+        for p in ports:
+            is_ch340_vid = p.vid == 0x1A86
+            is_ch340_str = "1a86" in p.device.lower() or (
+                p.manufacturer is not None and "1a86" in p.manufacturer.lower()
+            )
+            if is_ch340_vid or is_ch340_str:
+                logger.info(f"Auto-detect: Found S0PCM candidate device at '{p.device}' (CH340)")
+                return p.device
+
+        # 2. Look for any other USB serial port (has "usb" in path or description)
+        for p in ports:
+            if "usb" in p.device.lower() or (p.description is not None and "usb" in p.description.lower()):
+                logger.info(f"Auto-detect: Selecting first available USB serial port '{p.device}' ({p.description})")
+                return p.device
+
+        # 3. Fallback to the first available port
+        first_port = ports[0].device
+        logger.info(f"Auto-detect: No USB-serial candidate found. Selecting first port '{first_port}'")
+        return first_port
+    except Exception as e:
+        logger.error(f"Auto-detect: Exception during port scan: {e}. Defaulting to /dev/ttyACM0")
+        return "/dev/ttyACM0"
+
+
 def read_config(
     version: str = "Unknown",
     config_dir: Path = Path("./"),
@@ -136,9 +173,12 @@ def read_config(
         if not tls_ca_path.is_absolute():
             tls_ca = str(config_dir / tls_ca)
 
+    device_opt = ha_options.get("device")
+    resolved_port = _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
+
     model = ConfigModel(
         log=LogConfig(level=(ha_options.get("log_level") or "INFO").upper()),
-        serial=SerialConfig(port=ha_options.get("device", "/dev/ttyACM0")),
+        serial=SerialConfig(port=resolved_port),
         mqtt=MqttConfig(
             host=mqtt_opts.get("host") or mqtt_service.get("host", "127.0.0.1"),
             port=mqtt_opts.get("port") or mqtt_service.get("port", 1883),

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -9,9 +9,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any
 
-import paho.mqtt.client as mqtt
 from pydantic import BaseModel, Field, SecretStr
 import serialx
 
@@ -53,7 +51,7 @@ class MqttConfig(BaseModel):
     password: SecretStr | None = None
     base_topic: str = "s0pcmreader"
     client_id: str | None = None
-    version: Any = mqtt.MQTTv5
+    version: str = "5.0"
     retain: bool = True
     split_topic: bool = True
     connect_retry: int = 5
@@ -131,8 +129,6 @@ def read_config(
     sec_opts = ha_options.get("security", {})
 
     mqtt_version_str = str(mqtt_opts.get("protocol", "5.0"))
-    version_map = {"3.1": mqtt.MQTTv31, "3.1.1": mqtt.MQTTv311, "5.0": mqtt.MQTTv5}
-    mqtt_version = version_map.get(mqtt_version_str, mqtt.MQTTv5)
 
     tls_ca = sec_opts.get("tls_ca", "")
     if tls_ca:
@@ -151,7 +147,7 @@ def read_config(
             password=mqtt_opts.get("password") or mqtt_service.get("password"),
             base_topic=mqtt_opts.get("base_topic", "s0pcmreader"),
             client_id=mqtt_opts.get("client_id") if mqtt_opts.get("client_id") not in [None, "", "None"] else None,
-            version=mqtt_version,
+            version=mqtt_version_str,
             retain=adv_opts.get("retain", True),
             split_topic=adv_opts.get("split_topic", True),
             discovery=adv_opts.get("discovery", True),

--- a/rootfs/usr/src/config.py
+++ b/rootfs/usr/src/config.py
@@ -6,6 +6,7 @@ Home Assistant options.json and Supervisor API.
 """
 
 import argparse
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -93,14 +94,14 @@ def init_args() -> Path:
     return config_path
 
 
-def _auto_detect_serial_port() -> str:
+async def _auto_detect_serial_port() -> str:
     """
     Auto-detect the S0PCM serial port on the system.
 
     Looks for typical CH340 USB-serial chips first, then any USB-serial device.
     """
     try:
-        ports = serialx.list_serial_ports()
+        ports = await asyncio.to_thread(serialx.list_serial_ports)
         if not ports:
             logger.warning("Auto-detect: No serial ports detected. Defaulting to /dev/ttyACM0")
             return "/dev/ttyACM0"
@@ -130,7 +131,7 @@ def _auto_detect_serial_port() -> str:
         return "/dev/ttyACM0"
 
 
-def read_config(
+async def read_config(
     version: str = "Unknown",
     config_dir: Path = Path("./"),
 ) -> ConfigModel:
@@ -147,16 +148,21 @@ def read_config(
     # 1. Load Home Assistant Options
     options_path = Path("/data/options.json")
     ha_options = {}
-    if options_path.exists():
-        try:
-            ha_options = json.loads(options_path.read_text())
-        except Exception as e:
-            logger.error(f"Failed to load {options_path}: {e}")
+
+    def _read_options():
+        if options_path.exists():
+            try:
+                return json.loads(options_path.read_text())
+            except Exception as e:
+                logger.error(f"Failed to load {options_path}: {e}")
+        return {}
+
+    ha_options = await asyncio.to_thread(_read_options)
 
     # 2. MQTT Service Discovery
     mqtt_service = {}
     if not ha_options.get("mqtt_host"):
-        mqtt_service = get_supervisor_config("mqtt")
+        mqtt_service = await get_supervisor_config("mqtt")
         if mqtt_service:
             logger.info("Using MQTT service discovery for connection settings.")
 
@@ -174,7 +180,7 @@ def read_config(
             tls_ca = str(config_dir / tls_ca)
 
     device_opt = ha_options.get("device")
-    resolved_port = _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
+    resolved_port = await _auto_detect_serial_port() if device_opt in [None, "", "null"] else device_opt
 
     model = ConfigModel(
         log=LogConfig(level=(ha_options.get("log_level") or "INFO").upper()),

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -142,9 +142,10 @@ def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int,
     }  # Link to global device
     raw_name = meter_state.name
     instancename = str(meter_id) if not raw_name or str(raw_name).lower() == "none" else str(raw_name)
-    # Defensive: strip MQTT special characters from topic names
+    # Defensive: strip MQTT special characters and non-printable characters from topic names
     for char in "/+#":
         instancename = instancename.replace(char, "")
+    instancename = "".join(c for c in instancename if c.isprintable())
 
     # Purge obsolete diagnostic sensors (PPS and Activity)
     for p_type, p_key in [("binary_sensor", "activity"), ("sensor", "pps")]:

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -8,7 +8,7 @@ import json
 import logging
 from typing import Final
 
-import paho.mqtt.client as mqtt
+import aiomqtt
 
 from state import AppContext, MeterState
 import utils
@@ -23,12 +23,12 @@ GLOBAL_DIAGNOSTICS: Final = [
 ]
 
 
-def send_global_discovery(mqttc: mqtt.Client, context: AppContext) -> None:
+async def send_global_discovery(client: aiomqtt.Client, context: AppContext) -> None:
     """
     Send discovery for global entities (Status, Error, Version, etc.)
 
     Args:
-        mqttc: The connected MQTT client.
+        client: The connected aiomqtt client.
         context: Application context.
     """
     if not context.config.mqtt.discovery:
@@ -58,11 +58,11 @@ def send_global_discovery(mqttc: mqtt.Client, context: AppContext) -> None:
         "payload_on": context.config.mqtt.online,
         "payload_off": context.config.mqtt.offline,
     }
-    mqttc.publish(status_topic, json.dumps(status_payload), retain=True)
+    await client.publish(status_topic, json.dumps(status_payload), retain=True)
 
     # Cleanup legacy
-    mqttc.publish(f"{discovery_prefix}/sensor/{base_topic}/s0pcm_{base_topic}_info/config", "", retain=True)
-    mqttc.publish(f"{discovery_prefix}/sensor/{base_topic}/s0pcm_{base_topic}_uptime/config", "", retain=True)
+    await client.publish(f"{discovery_prefix}/sensor/{base_topic}/s0pcm_{base_topic}_info/config", "", retain=True)
+    await client.publish(f"{discovery_prefix}/sensor/{base_topic}/s0pcm_{base_topic}_uptime/config", "", retain=True)
 
     # Error Sensor
     error_unique_id = f"s0pcm_{base_topic}_error"
@@ -79,7 +79,7 @@ def send_global_discovery(mqttc: mqtt.Client, context: AppContext) -> None:
             {"topic": base_topic + "/status", "value_template": "{{ 'online' }}", "payload_available": "online"}
         ],
     }
-    mqttc.publish(error_topic, json.dumps(error_payload), retain=True)
+    await client.publish(error_topic, json.dumps(error_payload), retain=True)
 
     ha_version = utils.get_ha_core_version()
     ha_version_tuple = utils.parse_ha_version(ha_version)
@@ -112,17 +112,19 @@ def send_global_discovery(mqttc: mqtt.Client, context: AppContext) -> None:
             diag_payload["unit_of_measurement"] = diag_data["unit"]
         if "class" in diag_data:
             diag_payload["device_class"] = diag_data["class"]
-        mqttc.publish(diag_topic, json.dumps(diag_payload), retain=True)
+        await client.publish(diag_topic, json.dumps(diag_payload), retain=True)
 
     logger.info("Sent global MQTT discovery messages")
 
 
-def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int, meter_state: MeterState) -> str | None:
+async def send_meter_discovery(
+    client: aiomqtt.Client, context: AppContext, meter_id: int, meter_state: MeterState
+) -> str | None:
     """
     Send discovery for a specific meter.
 
     Args:
-        mqttc: The connected MQTT client.
+        client: The connected aiomqtt client.
         context: Application context.
         meter_id: The unique ID of the meter.
         meter_state: The MeterState object for this meter.
@@ -151,7 +153,7 @@ def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int,
     for p_type, p_key in [("binary_sensor", "activity"), ("sensor", "pps")]:
         p_uid = f"s0pcm_{base_topic}_{meter_id}_{p_key}"
         p_topic = f"{discovery_prefix}/{p_type}/{base_topic}/{p_uid}/config"
-        mqttc.publish(p_topic, "", retain=True)
+        await client.publish(p_topic, "", retain=True)
 
     for subkey in ["total", "today", "yesterday"]:
         unique_id = f"s0pcm_{base_topic}_{meter_id}_{subkey}"
@@ -176,8 +178,8 @@ def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int,
             payload["value_template"] = f"{{{{ value_json.{subkey} }}}}"
 
         # Force refresh
-        mqttc.publish(topic, "", retain=True)
-        mqttc.publish(topic, json.dumps(payload), retain=True)
+        await client.publish(topic, "", retain=True)
+        await client.publish(topic, json.dumps(payload), retain=True)
 
         if subkey == "total":
             # Text Entity (Name)
@@ -192,8 +194,8 @@ def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int,
                 "state_topic": f"{base_topic}/{meter_id}/name",
                 "icon": "mdi:tag-text-outline",
             }
-            mqttc.publish(text_topic, "", retain=True)
-            mqttc.publish(text_topic, json.dumps(text_payload), retain=True)
+            await client.publish(text_topic, "", retain=True)
+            await client.publish(text_topic, json.dumps(text_payload), retain=True)
 
             # Number Entity (Total Correction)
             num_uid = f"s0pcm_{base_topic}_{meter_id}_total_config"
@@ -211,19 +213,19 @@ def send_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int,
                 "mode": "box",
                 "icon": "mdi:counter",
             }
-            mqttc.publish(num_topic, "", retain=True)
-            mqttc.publish(num_topic, json.dumps(num_payload), retain=True)
+            await client.publish(num_topic, "", retain=True)
+            await client.publish(num_topic, json.dumps(num_payload), retain=True)
 
     logger.info(f"Sent discovery for Meter {meter_id} ({instancename})")
     return instancename
 
 
-def cleanup_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: int) -> None:
+async def cleanup_meter_discovery(client: aiomqtt.Client, context: AppContext, meter_id: int) -> None:
     """
     Clear discovery for a specific meter ID (useful for purging ghost sensors).
 
     Args:
-        mqttc: The connected MQTT client.
+        client: The connected aiomqtt client.
         context: Application context.
         meter_id: The ID of the meter to clear.
     """
@@ -237,21 +239,21 @@ def cleanup_meter_discovery(mqttc: mqtt.Client, context: AppContext, meter_id: i
     for subkey in ["total", "today", "yesterday"]:
         unique_id = f"s0pcm_{base_topic}_{meter_id}_{subkey}"
         topic = f"{discovery_prefix}/sensor/{base_topic}/{unique_id}/config"
-        mqttc.publish(topic, "", retain=True)
+        await client.publish(topic, "", retain=True)
 
     # Clear configuration entities
     text_uid = f"s0pcm_{base_topic}_{meter_id}_name_config"
     text_topic = f"{discovery_prefix}/text/{base_topic}/{text_uid}/config"
-    mqttc.publish(text_topic, "", retain=True)
+    await client.publish(text_topic, "", retain=True)
 
     num_uid = f"s0pcm_{base_topic}_{meter_id}_total_config"
     num_topic = f"{discovery_prefix}/number/{base_topic}/{num_uid}/config"
-    mqttc.publish(num_topic, "", retain=True)
+    await client.publish(num_topic, "", retain=True)
 
     # Clear obsolete diagnostic sensors
     for p_type, p_key in [("binary_sensor", "activity"), ("sensor", "pps")]:
         p_uid = f"s0pcm_{base_topic}_{meter_id}_{p_key}"
         p_topic = f"{discovery_prefix}/{p_type}/{base_topic}/{p_uid}/config"
-        mqttc.publish(p_topic, "", retain=True)
+        await client.publish(p_topic, "", retain=True)
 
     logger.debug(f"Cleared MQTT discovery for Meter {meter_id}")

--- a/rootfs/usr/src/discovery.py
+++ b/rootfs/usr/src/discovery.py
@@ -81,7 +81,7 @@ async def send_global_discovery(client: aiomqtt.Client, context: AppContext) -> 
     }
     await client.publish(error_topic, json.dumps(error_payload), retain=True)
 
-    ha_version = utils.get_ha_core_version()
+    ha_version = await utils.get_ha_core_version()
     ha_version_tuple = utils.parse_ha_version(ha_version)
 
     # Diagnostics

--- a/rootfs/usr/src/healthcheck.py
+++ b/rootfs/usr/src/healthcheck.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import sys
 
 PROCESS_NAME = "s0pcm_reader.py"
+PROCESS_INTERPRETER = "python"
 
 
 def is_process_running(process_name: str = PROCESS_NAME) -> bool:
@@ -24,7 +25,7 @@ def is_process_running(process_name: str = PROCESS_NAME) -> bool:
                 continue
             try:
                 cmdline = (entry / "cmdline").read_bytes().decode("utf-8", errors="replace")
-                if process_name in cmdline:
+                if process_name in cmdline and PROCESS_INTERPRETER in cmdline:
                     return True
             except OSError, PermissionError:
                 continue

--- a/rootfs/usr/src/mqtt_handler.py
+++ b/rootfs/usr/src/mqtt_handler.py
@@ -167,10 +167,10 @@ class TaskDoMQTT(threading.Thread):
                 return
 
             new_name = msg.payload.decode("utf-8").strip()
-            # Sanitize MQTT special characters from meter names
+            # Sanitize MQTT special characters and non-printable characters from meter names
             for char in "/+#":
                 new_name = new_name.replace(char, "")
-            new_name = new_name.strip()
+            new_name = "".join(c for c in new_name if c.isprintable())
             if not new_name:
                 new_name = None
 

--- a/rootfs/usr/src/mqtt_handler.py
+++ b/rootfs/usr/src/mqtt_handler.py
@@ -4,15 +4,15 @@ MQTT Handler
 Manages MQTT connection, publishing sensor data, and handling discovery.
 """
 
+import asyncio
 from dataclasses import dataclass, field
 import json
 import logging
 import ssl
-import threading
-import time
 from typing import Any
 
-import paho.mqtt.client as mqtt
+import aiomqtt
+import paho.mqtt.client as paho_mqtt
 
 from constants import ConnectionStatus, MqttTopicSuffix
 import discovery
@@ -23,422 +23,387 @@ logger = logging.getLogger(__name__)
 
 MAX_PAYLOAD_SIZE = 256
 
+# Background task set to hold strong references (prevents GC of fire-and-forget tasks)
+_background_tasks: set[asyncio.Task] = set()
+
+# Map config version strings to paho-mqtt protocol constants (used by aiomqtt internally)
+MQTT_VERSION_MAP: dict[str, int] = {
+    "3.1": paho_mqtt.MQTTv31,
+    "3.1.1": paho_mqtt.MQTTv311,
+    "5.0": paho_mqtt.MQTTv5,
+}
+
 
 @dataclass
 class MqttTaskState:
     """Internal state for MQTT task."""
 
-    connected: bool = False
     global_discovery_sent: bool = False
     discovered_meters: dict[int, str] = field(default_factory=dict)
     recovery_complete: bool = False
-    mqttc: mqtt.Client | None = None
     last_diagnostics: dict[str, Any] = field(default_factory=dict)
     last_info_payload: str | None = None
     last_error_msg: str | None = None
-    error_clear_armed_time: float | None = None
 
 
-class TaskDoMQTT(threading.Thread):
-    """
-    Task to handle MQTT communications.
+def _resolve_meter_id(context: state_module.AppContext, identifier: str) -> int | None:
+    """Resolve a meter identifier (ID or Name) to a numeric Meter ID."""
+    try:
+        return int(identifier)
+    except ValueError:
+        for mid, mstate in context.state.meters.items():
+            if mstate.name and mstate.name.lower() == identifier.lower():
+                return mid
+    return None
 
-    Responsible for connecting to the broker, performing state recovery on startup,
-    subscribing to commands, and publishing meter data and diagnostics.
-    """
 
-    def __init__(self, context: state_module.AppContext, trigger: threading.Event, stopper: threading.Event) -> None:
-        """
-        Initialize the MQTT task.
+async def _handle_set_command(context: state_module.AppContext, topic: str, payload: bytes) -> None:
+    """Handle a total/set MQTT command."""
+    if len(payload) > MAX_PAYLOAD_SIZE:
+        context.set_error(f"Ignored oversized payload ({len(payload)} bytes) on {topic}", category="mqtt")
+        return
+    try:
+        parts = topic.split("/")
+        identifier = parts[-3]
+        meter_id = _resolve_meter_id(context, identifier)
 
-        Args:
-            context: Application context.
-            trigger: Event to signal when work (publishing) is needed.
-            stopper: Event to signal when the task should stop.
-        """
-        super().__init__()
-        self._trigger = trigger
-        self._stopper = stopper
-        self._state = MqttTaskState()
-        self.app_context = context
+        if meter_id is None:
+            context.set_error(f"Ignored set command for unknown meter: {identifier}", category="mqtt")
+            return
 
-    def _recover_state(self) -> None:
-        """Startup phase: Use StateRecoverer to restore totals."""
-        recoverer = StateRecoverer(self.app_context, self._state.mqttc)
-        recoverer.run()
-        self._state.recovery_complete = True
-        self.app_context.recovery_event.set()
-
-    def on_connect(
-        self, mqttc: mqtt.Client, obj: Any, flags: Any, reason_code: mqtt.ReasonCodes, properties: Any | None
-    ) -> None:
-        context = self.app_context
-        if reason_code == 0:
-            self._state.connected = True
-            logger.info("MQTT successfully connected to broker")
-            self._trigger.set()
-            self._state.mqttc.publish(
-                context.config.mqtt.base_topic + "/status",
-                ConnectionStatus.ONLINE,
-                retain=True,
-            )
-            self._state.mqttc.subscribe(context.config.mqtt.base_topic + "/+/total/set")
-            self._state.mqttc.subscribe(context.config.mqtt.base_topic + "/+/name/set")
-        else:
-            self._state.connected = False
-            context.set_error(f"MQTT failed to connect to broker: {mqtt.connack_string(reason_code)}", category="mqtt")
-
-    def on_disconnect(
-        self, mqttc: mqtt.Client, obj: Any, flags: Any, reason_code: mqtt.ReasonCodes, properties: Any | None
-    ) -> None:
-        context = self.app_context
-        self._state.connected = False
-        if reason_code != 0:
-            context.set_error(
-                f"MQTT failed to disconnect from broker: {mqtt.connack_string(reason_code)}", category="mqtt"
-            )
-            logger.error(f"MQTT disconnected unexpectedly. Reason: {reason_code}")
-
-    def _resolve_meter_id(self, identifier: str) -> int | None:
-        """Resolve a meter identifier (ID or Name) to a numeric Meter ID."""
+        payload_str = payload.decode("utf-8")
         try:
-            return int(identifier)
+            new_total = int(float(payload_str))
         except ValueError:
-            for mid, mstate in self.app_context.state.meters.items():
-                if mstate.name and mstate.name.lower() == identifier.lower():
-                    return mid
-        return None
-
-    def on_message(self, mqttc: mqtt.Client, obj: Any, msg: mqtt.MQTTMessage) -> None:
-        logger.debug("MQTT on_message: " + msg.topic + " " + str(msg.qos) + " " + str(msg.payload))
-        match msg.topic:
-            case str(topic) if topic.endswith("/total/set"):
-                self._handle_set_command(msg)
-            case str(topic) if topic.endswith("/name/set"):
-                self._handle_name_set(msg)
-
-    def _handle_set_command(self, msg: mqtt.MQTTMessage) -> None:
-        context = self.app_context
-        if len(msg.payload) > MAX_PAYLOAD_SIZE:
-            context.set_error(f"Ignored oversized payload ({len(msg.payload)} bytes) on {msg.topic}", category="mqtt")
-            return
-        try:
-            parts = msg.topic.split("/")
-            identifier = parts[-3]
-            meter_id = self._resolve_meter_id(identifier)
-
-            if meter_id is None:
-                context.set_error(f"Ignored set command for unknown meter: {identifier}", category="mqtt")
-                return
-
-            payload_str = msg.payload.decode("utf-8")
-            try:
-                new_total = int(float(payload_str))
-            except ValueError:
-                context.set_error(
-                    f"Ignored invalid payload for set command on meter {meter_id}: {payload_str}", category="mqtt"
-                )
-                return
-
-            logger.info(f"Received MQTT set command for meter {meter_id}. Setting total to {new_total}.")
-
-            with context.lock:
-                if meter_id not in context.state.meters:
-                    context.state.meters[meter_id] = state_module.MeterState()
-                context.state.meters[meter_id].total = new_total
-                context.state_share = context.state.model_copy(deep=True)
-                self._trigger.set()
-
-        except Exception as e:
-            context.set_error(f"Failed to process MQTT set command: {e}", category="mqtt")
-
-    def _handle_name_set(self, msg: mqtt.MQTTMessage) -> None:
-        context = self.app_context
-        if len(msg.payload) > MAX_PAYLOAD_SIZE:
-            context.set_error(f"Ignored oversized payload ({len(msg.payload)} bytes) on {msg.topic}", category="mqtt")
-            return
-        try:
-            parts = msg.topic.split("/")
-            identifier = parts[-3]
-            meter_id = self._resolve_meter_id(identifier)
-
-            if meter_id is None:
-                context.set_error(f"Ignored name/set command for unknown meter: {identifier}", category="mqtt")
-                return
-
-            new_name = msg.payload.decode("utf-8").strip()
-            # Sanitize MQTT special characters and non-printable characters from meter names
-            for char in "/+#":
-                new_name = new_name.replace(char, "")
-            new_name = "".join(c for c in new_name if c.isprintable())
-            if not new_name:
-                new_name = None
-
-            logger.info(f"Received MQTT name/set command for meter {meter_id}. Setting name to: {new_name or 'None'}")
-
-            with context.lock:
-                if meter_id not in context.state.meters:
-                    context.state.meters[meter_id] = state_module.MeterState()
-                context.state.meters[meter_id].name = new_name
-                context.state_share = context.state.model_copy(deep=True)
-
-                # Re-trigger discovery
-                discovery.send_global_discovery(self._state.mqttc, context)
-                for mid, mstate in context.state.meters.items():
-                    instancename = discovery.send_meter_discovery(self._state.mqttc, context, mid, mstate)
-                    if instancename:
-                        self._state.discovered_meters[mid] = instancename
-                self._state.global_discovery_sent = True
-                self._trigger.set()
-
-        except Exception as e:
-            context.set_error(f"Failed to process MQTT name/set command: {e}", category="mqtt")
-
-    def _setup_mqtt_client(self, use_tls) -> bool:
-        context = self.app_context
-        self._state.mqttc = mqtt.Client(
-            mqtt.CallbackAPIVersion.VERSION2,
-            client_id=context.config.mqtt.client_id,
-            protocol=context.config.mqtt.version,
-        )
-        self._state.mqttc.on_connect = self.on_connect
-        self._state.mqttc.on_disconnect = self.on_disconnect
-        self._state.mqttc.on_message = self.on_message
-
-        if context.config.mqtt.username is not None:
-            self._state.mqttc.username_pw_set(
-                context.config.mqtt.username.get_secret_value(),
-                context.config.mqtt.password.get_secret_value() if context.config.mqtt.password else None,
+            context.set_error(
+                f"Ignored invalid payload for set command on meter {meter_id}: {payload_str}", category="mqtt"
             )
+            return
 
-        if use_tls:
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            if context.config.mqtt.tls_ca == "":
-                ssl_context.check_hostname = False
-                ssl_context.verify_mode = ssl.CERT_NONE
-            else:
-                if context.config.mqtt.tls_check_peer:
-                    ssl_context.verify_mode = ssl.CERT_REQUIRED
-                    ssl_context.check_hostname = True
+        logger.info(f"Received MQTT set command for meter {meter_id}. Setting total to {new_total}.")
+
+        if meter_id not in context.state.meters:
+            context.state.meters[meter_id] = state_module.MeterState()
+        context.state.meters[meter_id].total = new_total
+        context.trigger_event.set()
+
+    except Exception as e:
+        context.set_error(f"Failed to process MQTT set command: {e}", category="mqtt")
+
+
+async def _handle_name_set(
+    context: state_module.AppContext,
+    client: aiomqtt.Client,
+    task_state: MqttTaskState,
+    topic: str,
+    payload: bytes,
+) -> None:
+    """Handle a name/set MQTT command."""
+    if len(payload) > MAX_PAYLOAD_SIZE:
+        context.set_error(f"Ignored oversized payload ({len(payload)} bytes) on {topic}", category="mqtt")
+        return
+    try:
+        parts = topic.split("/")
+        identifier = parts[-3]
+        meter_id = _resolve_meter_id(context, identifier)
+
+        if meter_id is None:
+            context.set_error(f"Ignored name/set command for unknown meter: {identifier}", category="mqtt")
+            return
+
+        new_name = payload.decode("utf-8").strip()
+        # Sanitize MQTT special characters and non-printable characters from meter names
+        for char in "/+#":
+            new_name = new_name.replace(char, "")
+        new_name = "".join(c for c in new_name if c.isprintable())
+        if not new_name:
+            new_name = None
+
+        logger.info(f"Received MQTT name/set command for meter {meter_id}. Setting name to: {new_name or 'None'}")
+
+        if meter_id not in context.state.meters:
+            context.state.meters[meter_id] = state_module.MeterState()
+        context.state.meters[meter_id].name = new_name
+
+        # Re-trigger discovery
+        await discovery.send_global_discovery(client, context)
+        for mid, mstate in context.state.meters.items():
+            instancename = await discovery.send_meter_discovery(client, context, mid, mstate)
+            if instancename:
+                task_state.discovered_meters[mid] = instancename
+        task_state.global_discovery_sent = True
+        context.trigger_event.set()
+
+    except Exception as e:
+        context.set_error(f"Failed to process MQTT name/set command: {e}", category="mqtt")
+
+
+async def _message_listener(
+    context: state_module.AppContext,
+    client: aiomqtt.Client,
+    task_state: MqttTaskState,
+) -> None:
+    """Listen for incoming MQTT messages (set commands, name changes)."""
+    async for message in client.messages:
+        topic = str(message.topic)
+        logger.debug(f"MQTT on_message: {topic} {message.payload}")
+        if topic.endswith("/total/set"):
+            await _handle_set_command(context, topic, message.payload)
+        elif topic.endswith("/name/set"):
+            await _handle_name_set(context, client, task_state, topic, message.payload)
+
+
+async def _publish_diagnostics(
+    context: state_module.AppContext,
+    client: aiomqtt.Client,
+    task_state: MqttTaskState,
+) -> None:
+    """Publish diagnostic information to MQTT."""
+    try:
+        current_diagnostics = {
+            "version": context.s0pcm_reader_version,
+            "firmware": context.s0pcm_firmware,
+            "startup_time": context.startup_time,
+            "port": context.config.serial.port,
+        }
+
+        for key, val in current_diagnostics.items():
+            if key not in task_state.last_diagnostics or task_state.last_diagnostics[key] != val:
+                topic = context.config.mqtt.base_topic + "/" + key
+                await client.publish(topic, str(val), retain=context.config.mqtt.retain)
+                task_state.last_diagnostics[key] = val
+
+        info_payload = json.dumps(current_diagnostics)
+        if task_state.last_info_payload != info_payload:
+            await client.publish(
+                context.config.mqtt.base_topic + "/info",
+                info_payload,
+                retain=context.config.mqtt.retain,
+            )
+            task_state.last_info_payload = info_payload
+    except Exception as e:
+        logger.error(f"Failed to publish info state to MQTT: {e}")
+
+
+async def _publish_measurements(
+    context: state_module.AppContext,
+    client: aiomqtt.Client,
+    state_snapshot: state_module.AppState,
+    previous_snapshot: state_module.AppState | None,
+) -> None:
+    """Publish meter measurements to MQTT."""
+    # Date
+    current_date_str = str(state_snapshot.date)
+    previous_date_str = str(previous_snapshot.date) if previous_snapshot else ""
+    if current_date_str != previous_date_str:
+        await client.publish(context.config.mqtt.base_topic + "/date", current_date_str, retain=True)
+
+    for mid, mstate in state_snapshot.meters.items():
+        if not mstate.enabled:
+            continue
+
+        instancename = mstate.name if mstate.name else str(mid)
+        prev_mstate = previous_snapshot.meters.get(mid) if previous_snapshot else None
+
+        # Internal topics for recovery
+        for topic_field in [
+            MqttTopicSuffix.TOTAL,
+            MqttTopicSuffix.TODAY,
+            MqttTopicSuffix.YESTERDAY,
+            MqttTopicSuffix.PULSECOUNT,
+        ]:
+            val = getattr(mstate, topic_field)
+            old_val = getattr(prev_mstate, topic_field) if prev_mstate else None
+            if val != old_val:
+                topic = f"{context.config.mqtt.base_topic}/{mid}/{topic_field}"
+                await client.publish(topic, val, retain=True)
+                logger.debug(f"MQTT Publish: topic='{topic}', value='{val}'")
+
+        # High-level topics
+        jsondata = {}
+        for topic_field in [MqttTopicSuffix.TOTAL, MqttTopicSuffix.TODAY, MqttTopicSuffix.YESTERDAY]:
+            val = getattr(mstate, topic_field)
+            old_val = getattr(prev_mstate, topic_field) if prev_mstate else -1
+
+            if val != old_val or (prev_mstate and mstate.name != prev_mstate.name):
+                if context.config.mqtt.split_topic:
+                    topic = f"{context.config.mqtt.base_topic}/{instancename}/{topic_field}"
+                    await client.publish(topic, val, retain=context.config.mqtt.retain)
+                    logger.debug(f"MQTT Publish: topic='{topic}', value='{val}'")
                 else:
-                    ssl_context.check_hostname = False
-                    ssl_context.verify_mode = ssl.CERT_NONE
+                    jsondata[topic_field] = val
 
-                try:
-                    ssl_context.load_verify_locations(cafile=context.config.mqtt.tls_ca)
-                except Exception as e:
-                    context.set_error(
-                        f"Failed to load TLS CA file '{context.config.mqtt.tls_ca}': {e}", category="mqtt"
-                    )
-                    return False
-            self._state.mqttc.tls_set_context(context=ssl_context)
+        # Name state
+        if not prev_mstate or mstate.name != prev_mstate.name:
+            topic = f"{context.config.mqtt.base_topic}/{mid}/name"
+            val = mstate.name if mstate.name else ""
+            await client.publish(topic, val, retain=True)
+            logger.debug(f"MQTT Publish Name: topic='{topic}', value='{val}'")
 
-        self._state.mqttc.will_set(
-            context.config.mqtt.base_topic + "/status",
-            ConnectionStatus.OFFLINE,
-            retain=True,
-        )
-        return True
+        # JSON publish
+        if not context.config.mqtt.split_topic and jsondata:
+            topic = f"{context.config.mqtt.base_topic}/{instancename}"
+            await client.publish(topic, json.dumps(jsondata), retain=context.config.mqtt.retain)
+            logger.debug(f"MQTT Publish: topic='{topic}', value='{json.dumps(jsondata)}'")
 
-    def _connect_loop(self) -> None:
-        context = self.app_context
-        use_tls = context.config.mqtt.tls
 
-        while not self._stopper.is_set():
-            if not self._state.mqttc and not self._setup_mqtt_client(use_tls):
-                time.sleep(context.config.mqtt.connect_retry)
-                continue
+async def _publish_loop(
+    context: state_module.AppContext,
+    client: aiomqtt.Client,
+    task_state: MqttTaskState,
+) -> None:
+    """Main publish loop — waits for trigger events and publishes data."""
+    previous_snapshot = None
 
+    while True:
+        # Take a snapshot of current state for diff-based publishing
+        state_snapshot = context.state.model_copy(deep=True)
+        error_msg = context.lasterror_share
+
+        if not task_state.global_discovery_sent:
+            await discovery.send_global_discovery(client, context)
+            # Purge all potential meters first to clear ghosts
+            for mid in range(1, 6):
+                await discovery.cleanup_meter_discovery(client, context, mid)
+            task_state.global_discovery_sent = True
+
+        for mid, mstate in state_snapshot.meters.items():
+            current_name = mstate.name if mstate.name else str(mid)
+            if mid not in task_state.discovered_meters or task_state.discovered_meters[mid] != current_name:
+                instancename = await discovery.send_meter_discovery(client, context, mid, mstate)
+                if instancename:
+                    task_state.discovered_meters[mid] = instancename
+
+        await _publish_diagnostics(context, client, task_state)
+        await _publish_measurements(context, client, state_snapshot, previous_snapshot)
+
+        # Publish Error (only on change)
+        try:
+            error_to_publish = error_msg if error_msg else "No Error"
+            if task_state.last_error_msg != error_to_publish:
+                await client.publish(
+                    context.config.mqtt.base_topic + "/error",
+                    error_to_publish,
+                    retain=context.config.mqtt.retain,
+                )
+                task_state.last_error_msg = error_to_publish
+
+                # If we just successfully published a REAL connection failure, launch a robust
+                # 15-second background timer to clear it later, bypassing any rapid serial events.
+                # This completely avoids race conditions with HA's state ingestion.
+                if error_to_publish != "No Error":
+
+                    async def delayed_clear():
+                        await asyncio.sleep(15.0)
+                        context.set_error(None, category="mqtt")
+
+                    task = asyncio.create_task(delayed_clear())
+                    _background_tasks.add(task)
+                    task.add_done_callback(_background_tasks.discard)
+        except Exception as e:
+            logger.error(f"MQTT Publish Failed for error: {e}")
+
+        previous_snapshot = state_snapshot
+        await context.trigger_event.wait()
+        context.trigger_event.clear()
+
+
+def _build_ssl_context(context: state_module.AppContext) -> ssl.SSLContext | None:
+    """Build an SSL context from configuration, or None on failure."""
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if context.config.mqtt.tls_ca == "":
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+    else:
+        if context.config.mqtt.tls_check_peer:
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.check_hostname = True
+        else:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+        try:
+            ssl_context.load_verify_locations(cafile=context.config.mqtt.tls_ca)
+        except Exception as e:
+            context.set_error(f"Failed to load TLS CA file '{context.config.mqtt.tls_ca}': {e}", category="mqtt")
+            return None
+    return ssl_context
+
+
+async def mqtt_task(context: state_module.AppContext) -> None:
+    """Main MQTT task coroutine."""
+    task_state = MqttTaskState()
+
+    try:
+        while True:
+            use_tls = context.config.mqtt.tls
             port = int(context.config.mqtt.tls_port if use_tls else context.config.mqtt.port)
+            base_topic = context.config.mqtt.base_topic
+
+            # Build TLS context if needed
+            tls_context = None
+            if use_tls:
+                tls_context = _build_ssl_context(context)
+                if tls_context is None:
+                    await asyncio.sleep(context.config.mqtt.connect_retry)
+                    continue
+
+            # Resolve protocol version
+            protocol = MQTT_VERSION_MAP.get(context.config.mqtt.version, paho_mqtt.MQTTv5)
+
+            # Prepare credentials
+            username = context.config.mqtt.username.get_secret_value() if context.config.mqtt.username else None
+            password = context.config.mqtt.password.get_secret_value() if context.config.mqtt.password else None
+
             logger.debug(f"Connecting to MQTT Broker '{context.config.mqtt.host}:{port}' (TLS: {use_tls})")
 
             try:
-                self._state.mqttc.connect(context.config.mqtt.host, port, 60)
-                self._state.mqttc.loop_start()
+                async with aiomqtt.Client(
+                    hostname=context.config.mqtt.host,
+                    port=port,
+                    identifier=context.config.mqtt.client_id,
+                    username=username,
+                    password=password,
+                    protocol=protocol,
+                    tls_context=tls_context,
+                    will=aiomqtt.Will(
+                        topic=base_topic + "/status",
+                        payload=ConnectionStatus.OFFLINE,
+                        retain=True,
+                    ),
+                ) as client:
+                    logger.info("MQTT successfully connected to broker")
 
-                timeout = time.time() + 10
-                while time.time() < timeout and not self._state.connected and not self._stopper.is_set():
-                    time.sleep(0.5)
+                    # Publish online status and subscribe to command topics
+                    await client.publish(base_topic + "/status", ConnectionStatus.ONLINE, retain=True)
+                    await client.subscribe(base_topic + "/+/total/set")
+                    await client.subscribe(base_topic + "/+/name/set")
 
-                if self._state.connected:
-                    self._recover_state()
-                    return
-                else:
-                    raise ConnectionError("Timeout waiting for MQTT CONNACK")
+                    # Recovery phase (only on first connect)
+                    if not task_state.recovery_complete:
+                        recoverer = StateRecoverer(context, client)
+                        await recoverer.run()
+                        task_state.recovery_complete = True
+                        context.recovery_event.set()
+
+                    # Run listener + publisher concurrently
+                    async with asyncio.TaskGroup() as tg:
+                        tg.create_task(_message_listener(context, client, task_state))
+                        tg.create_task(_publish_loop(context, client, task_state))
 
             except Exception as e:
-                if self._state.mqttc:
-                    self._state.mqttc.loop_stop()
-                    self._state.mqttc = None
-
-                # Format a clean error string
                 err_str = f"MQTT connection failed: {e}"
                 context.set_error(err_str, category="mqtt")
                 logger.error(err_str)
-                time.sleep(context.config.mqtt.connect_retry)
+                # Reset discovery state on disconnect so it re-sends on reconnect
+                task_state.global_discovery_sent = False
+                task_state.discovered_meters.clear()
+                task_state.last_diagnostics.clear()
+                task_state.last_info_payload = None
+                task_state.last_error_msg = None
+                await asyncio.sleep(context.config.mqtt.connect_retry)
 
-    def _publish_diagnostics(self) -> None:
-        context = self.app_context
-        try:
-            current_diagnostics = {
-                "version": context.s0pcm_reader_version,
-                "firmware": context.s0pcm_firmware,
-                "startup_time": context.startup_time,
-                "port": context.config.serial.port,
-            }
-
-            for key, val in current_diagnostics.items():
-                if key not in self._state.last_diagnostics or self._state.last_diagnostics[key] != val:
-                    topic = context.config.mqtt.base_topic + "/" + key
-                    self._state.mqttc.publish(topic, str(val), retain=context.config.mqtt.retain)
-                    self._state.last_diagnostics[key] = val
-
-            info_payload = json.dumps(current_diagnostics)
-            if self._state.last_info_payload != info_payload:
-                self._state.mqttc.publish(
-                    context.config.mqtt.base_topic + "/info",
-                    info_payload,
-                    retain=context.config.mqtt.retain,
-                )
-                self._state.last_info_payload = info_payload
-        except Exception as e:
-            logger.error(f"Failed to publish info state to MQTT: {e}")
-
-    def _publish_measurements(
-        self, state_snapshot: state_module.AppState, previous_snapshot: state_module.AppState | None
-    ) -> None:
-        context = self.app_context
-
-        # Date
-        current_date_str = str(state_snapshot.date)
-        previous_date_str = str(previous_snapshot.date) if previous_snapshot else ""
-        if current_date_str != previous_date_str:
-            self._state.mqttc.publish(context.config.mqtt.base_topic + "/date", current_date_str, retain=True)
-
-        for mid, mstate in state_snapshot.meters.items():
-            if not mstate.enabled:
-                continue
-
-            instancename = mstate.name if mstate.name else str(mid)
-            prev_mstate = previous_snapshot.meters.get(mid) if previous_snapshot else None
-
-            # Internal topics for recovery
-            for topic_field in [
-                MqttTopicSuffix.TOTAL,
-                MqttTopicSuffix.TODAY,
-                MqttTopicSuffix.YESTERDAY,
-                MqttTopicSuffix.PULSECOUNT,
-            ]:
-                val = getattr(mstate, topic_field)
-                old_val = getattr(prev_mstate, topic_field) if prev_mstate else None
-                if val != old_val:
-                    topic = f"{context.config.mqtt.base_topic}/{mid}/{topic_field}"
-                    self._state.mqttc.publish(topic, val, retain=True)
-                    logger.debug(f"MQTT Publish: topic='{topic}', value='{val}'")
-
-            # High-level topics
-            jsondata = {}
-            for topic_field in [MqttTopicSuffix.TOTAL, MqttTopicSuffix.TODAY, MqttTopicSuffix.YESTERDAY]:
-                val = getattr(mstate, topic_field)
-                old_val = getattr(prev_mstate, topic_field) if prev_mstate else -1
-
-                if val != old_val or (prev_mstate and mstate.name != prev_mstate.name):
-                    if context.config.mqtt.split_topic:
-                        topic = f"{context.config.mqtt.base_topic}/{instancename}/{topic_field}"
-                        self._state.mqttc.publish(topic, val, retain=context.config.mqtt.retain)
-                        logger.debug(f"MQTT Publish: topic='{topic}', value='{val}'")
-                    else:
-                        jsondata[topic_field] = val
-
-            # Name state
-            if not prev_mstate or mstate.name != prev_mstate.name:
-                topic = f"{context.config.mqtt.base_topic}/{mid}/name"
-                val = mstate.name if mstate.name else ""
-                self._state.mqttc.publish(topic, val, retain=True)
-                logger.debug(f"MQTT Publish Name: topic='{topic}', value='{val}'")
-
-            # JSON publish
-            if not context.config.mqtt.split_topic and jsondata:
-                topic = f"{context.config.mqtt.base_topic}/{instancename}"
-                self._state.mqttc.publish(topic, json.dumps(jsondata), retain=context.config.mqtt.retain)
-                logger.debug(f"MQTT Publish: topic='{topic}', value='{json.dumps(jsondata)}'")
-
-    def _main_loop(self) -> None:
-        context = self.app_context
-        previous_snapshot = None
-
-        while not self._stopper.is_set():
-            with context.lock:
-                state_snapshot = context.state_share.model_copy(deep=True)
-                error_msg = context.lasterror_share
-
-            if not self._state.connected:
-                return
-
-            if not self._state.global_discovery_sent:
-                discovery.send_global_discovery(self._state.mqttc, context)
-                # Purge all potential meters first to clear ghosts
-                for mid in range(1, 6):
-                    discovery.cleanup_meter_discovery(self._state.mqttc, context, mid)
-                self._state.global_discovery_sent = True
-
-            for mid, mstate in state_snapshot.meters.items():
-                current_name = mstate.name if mstate.name else str(mid)
-                if mid not in self._state.discovered_meters or self._state.discovered_meters[mid] != current_name:
-                    instancename = discovery.send_meter_discovery(self._state.mqttc, context, mid, mstate)
-                    if instancename:
-                        self._state.discovered_meters[mid] = instancename
-
-            self._publish_diagnostics()
-            self._publish_measurements(state_snapshot, previous_snapshot)
-
-            # Publish Error (only on change)
-            try:
-                error_to_publish = error_msg if error_msg else "No Error"
-                if self._state.last_error_msg != error_to_publish:
-                    self._state.mqttc.publish(
-                        context.config.mqtt.base_topic + "/error",
-                        error_to_publish,
-                        retain=context.config.mqtt.retain,
-                    )
-                    self._state.last_error_msg = error_to_publish
-
-                    # If we just successfully published a REAL connection failure, launch a robust
-                    # 15-second background timer to clear it later, bypassing any rapid serial events.
-                    # This completely avoids race conditions with HA's state ingestion.
-                    if error_to_publish != "No Error":
-
-                        def delayed_clear():
-                            if self._state.connected:
-                                context.set_error(None, category="mqtt")
-
-                        timer = threading.Timer(15.0, delayed_clear)
-                        timer.daemon = True
-                        timer.start()
-            except Exception as e:
-                logger.error(f"MQTT Publish Failed for error: {e}")
-
-            previous_snapshot = state_snapshot
-            self._trigger.wait()
-            self._trigger.clear()
-
-    def run(self) -> None:
-        context = self.app_context
-        try:
-            while not self._stopper.is_set():
-                self._connect_loop()
-                self._main_loop()
-                if self._state.mqttc:
-                    if self._state.connected:
-                        self._state.mqttc.publish(
-                            context.config.mqtt.base_topic + "/status",
-                            ConnectionStatus.OFFLINE,
-                            retain=True,
-                        )
-                    self._state.mqttc.loop_stop()
-                    self._state.mqttc.disconnect()
-                    self._state.mqttc = None
-        except Exception:
-            logger.error("Fatal MQTT exception", exc_info=True)
-        finally:
-            self._stopper.set()
+    except asyncio.CancelledError:
+        logger.info("MQTT Task: Cancelled, shutting down.")
+    except Exception:
+        logger.error("Fatal MQTT exception", exc_info=True)

--- a/rootfs/usr/src/recovery.py
+++ b/rootfs/usr/src/recovery.py
@@ -33,7 +33,7 @@ class StateRecoverer:
         self.recovered_names = {}  # {id: name}
         self.context = context
 
-    def fetch_ha_state(self, entity_id: str) -> str | None:
+    async def fetch_ha_state(self, entity_id: str) -> str | None:
         """Fetch the current state of an entity from Home Assistant."""
         token = os.getenv("SUPERVISOR_TOKEN")
         if not token:
@@ -43,17 +43,22 @@ class StateRecoverer:
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=5) as response:
-                if response.status == 200:
-                    data = json.loads(response.read().decode())
-                    state = data.get("state")
-                    if state not in [None, "unknown", "unavailable"]:
-                        return state
+
+            def _fetch():
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        data = json.loads(response.read().decode())
+                        state = data.get("state")
+                        if state not in [None, "unknown", "unavailable"]:
+                            return state
+                return None
+
+            return await asyncio.to_thread(_fetch)
         except Exception as e:
             logger.debug(f"HA API state fetch for {entity_id} failed: {e}")
         return None
 
-    def fetch_all_ha_states(self) -> EntityStateList:
+    async def fetch_all_ha_states(self) -> EntityStateList:
         """Fetch all entity states from Home Assistant."""
         token = os.getenv("SUPERVISOR_TOKEN")
         if not token:
@@ -63,9 +68,14 @@ class StateRecoverer:
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=5) as response:
-                if response.status == 200:
-                    return json.loads(response.read().decode())
+
+            def _fetch():
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    if response.status == 200:
+                        return json.loads(response.read().decode())
+                return []
+
+            return await asyncio.to_thread(_fetch)
         except Exception as e:
             logger.debug(f"HA API fetch all states failed: {e}")
         return []
@@ -184,7 +194,7 @@ class StateRecoverer:
             if meter.total == 0:
                 if ha_states is None:
                     logger.info(f"Recovery: Meter {mid} not found on MQTT, attempting HA API fallback...")
-                    ha_states = await asyncio.to_thread(self.fetch_all_ha_states)
+                    ha_states = await self.fetch_all_ha_states()
 
                 found_val = self._find_total_in_ha(mid, ha_states)
                 if found_val is not None:

--- a/rootfs/usr/src/recovery.py
+++ b/rootfs/usr/src/recovery.py
@@ -4,16 +4,16 @@ Recovery Module
 Handles state recovery from MQTT retained messages and Home Assistant REST API.
 """
 
+import asyncio
 import datetime
 import json
 import logging
 import os
 import re
-import time
 from typing import Any
 import urllib.request
 
-import paho.mqtt.client as mqtt
+import aiomqtt
 
 import state as state_module
 import utils
@@ -27,8 +27,8 @@ type EntityStateList = list[dict[str, Any]]
 class StateRecoverer:
     """Helper class to manage the startup state recovery phase."""
 
-    def __init__(self, context: state_module.AppContext, mqttc: mqtt.Client):
-        self.mqttc = mqttc
+    def __init__(self, context: state_module.AppContext, client: aiomqtt.Client):
+        self.client = client
         self.recovered_data = {}  # {identifier: {'total': X}}
         self.recovered_names = {}  # {id: name}
         self.context = context
@@ -70,15 +70,15 @@ class StateRecoverer:
             logger.debug(f"HA API fetch all states failed: {e}")
         return []
 
-    def on_message(self, client, userdata, msg):
-        """Process messages for state recovery."""
+    def _process_message(self, topic: str, payload: bytes) -> None:
+        """Process a single retained message for state recovery."""
         base_topic = self.context.config.mqtt.base_topic
         try:
             # 1. Discovery topics (Name Mapping)
-            if "/config" in msg.topic:
-                payload = json.loads(msg.payload.decode())
-                unique_id = payload.get("unique_id", "")
-                state_topic = payload.get("state_topic", "")
+            if "/config" in topic:
+                decoded = json.loads(payload.decode())
+                unique_id = decoded.get("unique_id", "")
+                state_topic = decoded.get("state_topic", "")
 
                 match_id = re.search(rf"s0pcm_{base_topic}_(\d+)", unique_id)
                 if match_id:
@@ -91,36 +91,31 @@ class StateRecoverer:
                 return
 
             # 2. Data topics
-            topic_parts = msg.topic.split("/")
+            topic_parts = topic.split("/")
             if len(topic_parts) >= 3:
                 suffix = topic_parts[-1]
                 if suffix in ["total", "today", "yesterday", "pulsecount"]:
                     identifier = topic_parts[-2]
                     try:
-                        value = int(float(msg.payload.decode()))
+                        value = int(float(payload.decode()))
                         self.recovered_data.setdefault(identifier, {})[suffix] = value
                     except ValueError:
                         pass
 
-            if msg.topic.endswith("/date"):
+            if topic.endswith("/date"):
                 try:
-                    dt = datetime.date.fromisoformat(msg.payload.decode())
-                    with self.context.lock:
-                        self.context.state.date = dt
+                    dt = datetime.date.fromisoformat(payload.decode())
+                    self.context.state.date = dt
                 except ValueError:
                     pass
         except Exception as e:
             logger.debug(f"Recovery parse error: {e}")
 
-    def run(self):
+    async def run(self):
         """Execute the recovery process."""
         logger.info("Starting State Recovery phase...")
         base_topic = self.context.config.mqtt.base_topic
         discovery_prefix = self.context.config.mqtt.discovery_prefix
-
-        # Temporarily steal on_message
-        original_on_message = self.mqttc.on_message
-        self.mqttc.on_message = self.on_message
 
         # Subscribe to recovery topics
         topics = [
@@ -132,74 +127,76 @@ class StateRecoverer:
             f"{discovery_prefix}/sensor/{base_topic}/#",
         ]
         for t in topics:
-            self.mqttc.subscribe(t)
+            await self.client.subscribe(t)
 
         wait_time = self.context.config.mqtt.recovery_wait
         logger.info(f"Recovery: Waiting {wait_time}s for MQTT retained messages...")
-        time.sleep(wait_time)
+
+        # Collect retained messages during the wait period
+        try:
+            async with asyncio.timeout(wait_time):
+                async for message in self.client.messages:
+                    self._process_message(str(message.topic), message.payload)
+        except TimeoutError:
+            pass
 
         # Cleanup subscriptions
         for t in topics:
-            self.mqttc.unsubscribe(t)
-        self.mqttc.on_message = original_on_message
+            await self.client.unsubscribe(t)
 
         # Sync mapped data
-        with self.context.lock:
-            # First pass: discovered IDs from MQTT
-            for id_str, data in self.recovered_data.items():
-                try:
-                    meter_id = int(id_str)
-                except ValueError:
-                    continue
+        # First pass: discovered IDs from MQTT
+        for id_str, data in self.recovered_data.items():
+            try:
+                meter_id = int(id_str)
+            except ValueError:
+                continue
 
-                # Only initialize if there is actually data beyond zeroes
-                if any(data.get(k, 0) > 0 for k in ["total", "today", "pulsecount", "yesterday"]):
-                    if meter_id not in self.context.state.meters:
-                        self.context.state.meters[meter_id] = state_module.MeterState()
+            # Only initialize if there is actually data beyond zeroes
+            if any(data.get(k, 0) > 0 for k in ["total", "today", "pulsecount", "yesterday"]):
+                if meter_id not in self.context.state.meters:
+                    self.context.state.meters[meter_id] = state_module.MeterState()
 
-                    meter = self.context.state.meters[meter_id]
-                    meter.total = data.get("total", meter.total)
-                    meter.today = data.get("today", meter.today)
-                    meter.yesterday = data.get("yesterday", meter.yesterday)
-                    meter.pulsecount = data.get("pulsecount", meter.pulsecount)
+                meter = self.context.state.meters[meter_id]
+                meter.total = data.get("total", meter.total)
+                meter.today = data.get("today", meter.today)
+                meter.yesterday = data.get("yesterday", meter.yesterday)
+                meter.pulsecount = data.get("pulsecount", meter.pulsecount)
 
-            # Second pass: Names (only if ID was already found or if name is solid)
-            for mid, name in self.recovered_names.items():
-                if mid not in self.context.state.meters:
-                    self.context.state.meters[mid] = state_module.MeterState()
+        # Second pass: Names (only if ID was already found or if name is solid)
+        for mid, name in self.recovered_names.items():
+            if mid not in self.context.state.meters:
+                self.context.state.meters[mid] = state_module.MeterState()
 
-                meter = self.context.state.meters[mid]
-                meter.name = name
+            meter = self.context.state.meters[mid]
+            meter.name = name
 
-                # Check for data under the name topic too (split_topic format)
-                if name in self.recovered_data:
-                    meter.total = max(meter.total, self.recovered_data[name].get("total", 0))
-                    meter.today = max(meter.today, self.recovered_data[name].get("today", 0))
-                    meter.yesterday = max(meter.yesterday, self.recovered_data[name].get("yesterday", 0))
-                    meter.pulsecount = max(meter.pulsecount, self.recovered_data[name].get("pulsecount", 0))
+            # Check for data under the name topic too (split_topic format)
+            if name in self.recovered_data:
+                meter.total = max(meter.total, self.recovered_data[name].get("total", 0))
+                meter.today = max(meter.today, self.recovered_data[name].get("today", 0))
+                meter.yesterday = max(meter.yesterday, self.recovered_data[name].get("yesterday", 0))
+                meter.pulsecount = max(meter.pulsecount, self.recovered_data[name].get("pulsecount", 0))
 
-            # HA API Fallback for missing totals
-            ha_states = None
-            for mid, meter in self.context.state.meters.items():
-                if meter.total == 0:
-                    if ha_states is None:
-                        logger.info(f"Recovery: Meter {mid} not found on MQTT, attempting HA API fallback...")
-                        ha_states = self.fetch_all_ha_states()
+        # HA API Fallback for missing totals (blocking HTTP — run in thread)
+        ha_states = None
+        for mid, meter in self.context.state.meters.items():
+            if meter.total == 0:
+                if ha_states is None:
+                    logger.info(f"Recovery: Meter {mid} not found on MQTT, attempting HA API fallback...")
+                    ha_states = await asyncio.to_thread(self.fetch_all_ha_states)
 
-                    found_val = self._find_total_in_ha(mid, ha_states)
-                    if found_val is not None:
-                        meter.total = found_val
-                        logger.info(f"Recovery: Recovered total for meter {mid} from HA API: {found_val}")
+                found_val = self._find_total_in_ha(mid, ha_states)
+                if found_val is not None:
+                    meter.total = found_val
+                    logger.info(f"Recovery: Recovered total for meter {mid} from HA API: {found_val}")
 
-            # Baseline share
-            self.context.state_share = self.context.state.model_copy(deep=True)
-
-            # Summary logging (Useful for verification)
-            for mid, meter in self.context.state.meters.items():
-                logger.info(f"Recovered total for meter {mid}: {meter.total}")
-                logger.info(f"Recovered pulsecount for meter {mid}: {meter.pulsecount}")
-                logger.info(f"Recovered today for meter {mid}: {meter.today}")
-                logger.info(f"Recovered yesterday for meter {mid}: {meter.yesterday}")
+        # Summary logging (Useful for verification)
+        for mid, meter in self.context.state.meters.items():
+            logger.info(f"Recovered total for meter {mid}: {meter.total}")
+            logger.info(f"Recovered pulsecount for meter {mid}: {meter.pulsecount}")
+            logger.info(f"Recovered today for meter {mid}: {meter.today}")
+            logger.info(f"Recovered yesterday for meter {mid}: {meter.yesterday}")
 
         logger.info("State Recovery complete.")
 

--- a/rootfs/usr/src/s0pcm_reader.py
+++ b/rootfs/usr/src/s0pcm_reader.py
@@ -28,7 +28,7 @@ async def main() -> None:
     # Initialize Context
     context = state_module.get_context()
 
-    version = get_version()
+    version = await get_version()
     context.s0pcm_reader_version = version
 
     config_path = Path("./")
@@ -37,7 +37,7 @@ async def main() -> None:
 
     try:
         # Load Configuration into context
-        context.config = config_module.read_config(version=context.s0pcm_reader_version, config_dir=config_path)
+        context.config = await config_module.read_config(version=context.s0pcm_reader_version, config_dir=config_path)
     except ValidationError, Exception:
         logger.error("Fatal exception during startup", exc_info=True)
         sys.exit(1)

--- a/rootfs/usr/src/s0pcm_reader.py
+++ b/rootfs/usr/src/s0pcm_reader.py
@@ -5,50 +5,31 @@ This application reads pulse counters from S0PCM-2 or S0PCM-5 devices via serial
 and publishes the data (total, today, yesterday) to MQTT (Home Assistant compatible).
 """
 
+import asyncio
 import logging
 import signal
 import sys
-import threading
 from pathlib import Path
-from typing import Any
 
 from pydantic import ValidationError
 
 # ruff: noqa: I001
 import config as config_module
-from mqtt_handler import TaskDoMQTT
-from serial_handler import TaskReadSerial
+from mqtt_handler import mqtt_task
+from serial_handler import serial_task
 import state as state_module
 from utils import get_version
 
 logger = logging.getLogger(__name__)
 
 
-# ------------------------------------------------------------------------------------
-# Global Events (for signal handling and test access)
-# ------------------------------------------------------------------------------------
-trigger = threading.Event()
-stopper = threading.Event()
-
-
-def main() -> None:
+async def main() -> None:
     """Main application entry point."""
-    global trigger, stopper
-
     # Initialize Context
     context = state_module.get_context()
 
     version = get_version()
     context.s0pcm_reader_version = version
-
-    # Signal handling for graceful shutdown
-    def signal_handler(signum: int, frame: Any) -> None:
-        logger.info(f"Signal {signum} received, stopping...")
-        stopper.set()
-        trigger.set()  # Wake up threads waiting on trigger
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
 
     config_path = Path("./")
     if __name__ == "__main__":
@@ -61,26 +42,28 @@ def main() -> None:
         logger.error("Fatal exception during startup", exc_info=True)
         sys.exit(1)
 
-    # Register trigger with context
-    context.register_trigger(trigger)
-
     logger.info("Starting s0pcm-reader...")
 
-    # Start our SerialPort thread
-    t1 = TaskReadSerial(context, trigger, stopper)
-    t1.start()
+    # Signal handling for graceful shutdown via task cancellation
+    loop = asyncio.get_running_loop()
 
-    # Start our MQTT thread
-    t2 = TaskDoMQTT(context, trigger, stopper)
-    t2.start()
+    def signal_handler() -> None:
+        logger.info("Signal received, stopping...")
+        for task in asyncio.all_tasks(loop):
+            task.cancel()
 
-    # Wait for threads to finish
-    while t1.is_alive() or t2.is_alive():
-        t1.join(1)
-        t2.join(1)
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, signal_handler)
+
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(serial_task(context))
+            tg.create_task(mqtt_task(context))
+    except* asyncio.CancelledError:
+        pass
 
     logger.info("Stop: s0pcm-reader")
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    asyncio.run(main())

--- a/rootfs/usr/src/serial_handler.py
+++ b/rootfs/usr/src/serial_handler.py
@@ -26,10 +26,10 @@ class SerialTaskState:
     started: bool = False
 
 
-def _log_available_ports() -> None:
+async def _log_available_ports() -> None:
     """Log available serial ports for debugging on connection failure."""
     try:
-        ports = serialx.list_serial_ports()
+        ports = await asyncio.to_thread(serialx.list_serial_ports)
         if ports:
             port_list = ", ".join(p.device for p in ports)
             logger.info(f"Available serial ports: {port_list}")
@@ -225,7 +225,7 @@ async def serial_task(context: state_module.AppContext) -> None:
                 task_state.serialerror += 1
                 context.set_error(f"Serialport connection failed: {type(e).__name__}: '{e}'", category="serial")
                 if task_state.serialerror == 1:
-                    _log_available_ports()
+                    await _log_available_ports()
                 logger.error(f"Retry in {context.config.serial.connect_retry} seconds")
                 await asyncio.sleep(context.config.serial.connect_retry)
     except asyncio.CancelledError:

--- a/rootfs/usr/src/serial_handler.py
+++ b/rootfs/usr/src/serial_handler.py
@@ -168,6 +168,10 @@ class TaskReadSerial(threading.Thread):
             meter.total += delta
             meter.today += delta
 
+        # Clamp to 32-bit signed integer max (matches HA number entity max: 2,147,483,647)
+        meter.total = min(meter.total, 2_147_483_647)
+        meter.today = min(meter.today, 2_147_483_647)
+
     def _read_loop(self, ser: serialx.BaseSerial) -> None:
         """
         Continuous read loop from serial port.

--- a/rootfs/usr/src/serial_handler.py
+++ b/rootfs/usr/src/serial_handler.py
@@ -1,14 +1,13 @@
 """
 Serial Handler Module
 
-Contains the TaskReadSerial class for reading and parsing S0PCM data from serial port.
+Contains the serial_task coroutine for reading and parsing S0PCM data from serial port.
 """
 
+import asyncio
 from dataclasses import dataclass
 import datetime
 import logging
-import threading
-import time
 
 import serialx
 
@@ -27,223 +26,209 @@ class SerialTaskState:
     started: bool = False
 
 
-class TaskReadSerial(threading.Thread):
+def _log_available_ports() -> None:
+    """Log available serial ports for debugging on connection failure."""
+    try:
+        ports = serialx.list_serial_ports()
+        if ports:
+            port_list = ", ".join(p.device for p in ports)
+            logger.info(f"Available serial ports: {port_list}")
+        else:
+            logger.warning("No serial ports detected on system")
+    except Exception:
+        logger.debug("Unable to enumerate serial ports")
+
+
+def _handle_header(context: state_module.AppContext, datastr: str) -> None:
     """
-    Task to read the serial port and update meter measurements.
+    Parse header packet to extract firmware version.
 
-    This thread continuously reads from the configured serial port, parses S0PCM packets,
-    and updates the application state.
+    Args:
+        context: Application context.
+        datastr: Raw header string from serial port.
     """
+    logger.debug(f"Header Packet: '{datastr}'")
+    try:
+        if ":" in datastr:
+            context.s0pcm_firmware = datastr.split(":", 1)[1].strip()
+        else:
+            context.s0pcm_firmware = datastr[1:].strip()
+    except IndexError:
+        context.s0pcm_firmware = datastr
 
-    def __init__(self, context: state_module.AppContext, trigger: threading.Event, stopper: threading.Event) -> None:
-        """
-        Initialize the serial reader task.
 
-        Args:
-            context: Application context.
-            trigger: Event to signal when new data is available.
-            stopper: Event to signal when the task should stop.
-        """
-        super().__init__()
-        self._trigger = trigger
-        self._stopper = stopper
-        self._state = SerialTaskState()
-        self.app_context = context
+def _update_meter(
+    context: state_module.AppContext, meter_id: int, pulsecount: int, pulses_in_interval: int, interval: int
+) -> None:
+    """
+    Update logic for a single meter.
 
-    def _log_available_ports(self) -> None:
-        """Log available serial ports for debugging on connection failure."""
-        try:
-            ports = serialx.list_serial_ports()
-            if ports:
-                port_list = ", ".join(p.device for p in ports)
-                logger.info(f"Available serial ports: {port_list}")
-            else:
-                logger.warning("No serial ports detected on system")
-        except Exception:
-            logger.debug("Unable to enumerate serial ports")
+    Handles day-rollover and pulsecount increment/reset logic.
 
-    def _handle_header(self, datastr: str) -> None:
-        """
-        Parse header packet to extract firmware version.
+    Args:
+        context: Application context.
+        meter_id: The ID of the meter to update.
+        pulsecount: The current pulsecount from the device.
+        pulses_in_interval: The number of pulses received in the last interval.
+        interval: The duration of the last interval in seconds.
+    """
+    # Ensure meter exists
+    if meter_id not in context.state.meters:
+        context.state.meters[meter_id] = state_module.MeterState()
 
-        Args:
-            datastr: Raw header string from serial port.
-        """
-        logger.debug(f"Header Packet: '{datastr}'")
-        try:
-            if ":" in datastr:
-                self.app_context.s0pcm_firmware = datastr.split(":", 1)[1].strip()
-            else:
-                self.app_context.s0pcm_firmware = datastr[1:].strip()
-        except IndexError:
-            self.app_context.s0pcm_firmware = datastr
+    meter = context.state.meters[meter_id]
 
-    def _handle_data_packet(self, datastr: str) -> None:
-        """
-        Parse data packet and update measurements in state.
+    # Handle day-rollover
+    today = datetime.date.today()
+    if context.state.date != today:
+        logger.debug(f"Day changed from '{context.state.date}' to '{today}', rolling over counter '{meter_id}'.")
+        meter.yesterday = meter.today
+        meter.today = 0
+        # Note: context.state.date update should ideally happen once.
+        # We'll update it here so subsequent meters in the same packet also see the change.
+        context.state.date = today
 
-        Args:
-            datastr: Raw data packet string from serial port.
-        """
-        logger.debug(f"S0PCM Packet: '{datastr}'")
+    # Check delta and update
+    if pulsecount > meter.pulsecount:
+        logger.debug(f"Pulsecount changed from '{meter.pulsecount}' to '{pulsecount}' for meter {meter_id}")
+        delta = pulsecount - meter.pulsecount
+        meter.pulsecount = pulsecount
+        meter.total += delta
+        meter.today += delta
 
-        try:
-            parsed_data = parse_s0pcm_packet(datastr)
-            interval = parsed_data["interval"]
-            meters = parsed_data["meters"]
-        except (ValueError, KeyError) as e:
-            self.app_context.set_error(f"Invalid Packet: {e}. Packet: '{datastr}'", category="serial")
-            return
-
-        with self.app_context.lock:
-            for meter_id, data in meters.items():
-                self._update_meter(meter_id, data["pulsecount"], data["pulses_in_interval"], interval)
-
-            # Update shared state snapshot for MQTT
-            self.app_context.state_share = self.app_context.state.model_copy(deep=True)
-
-        # Clear serial error
-        self.app_context.set_error(None, category="serial")
-
-        # Signal MQTT task that new data is available
-        self._trigger.set()
-
-    def _update_meter(self, meter_id: int, pulsecount: int, pulses_in_interval: int, interval: int) -> None:
-        """
-        Update logic for a single meter.
-
-        Handles day-rollover and pulsecount increment/reset logic.
-
-        Args:
-            meter_id: The ID of the meter to update.
-            pulsecount: The current pulsecount from the device.
-            pulses_in_interval: The number of pulses received in the last interval.
-            interval: The duration of the last interval in seconds.
-        """
-        # Ensure meter exists
-        if meter_id not in self.app_context.state.meters:
-            self.app_context.state.meters[meter_id] = state_module.MeterState()
-
-        meter = self.app_context.state.meters[meter_id]
-
-        # Handle day-rollover
-        today = datetime.date.today()
-        if self.app_context.state.date != today:
-            logger.debug(
-                f"Day changed from '{self.app_context.state.date}' to '{today}', rolling over counter '{meter_id}'."
+    elif pulsecount < meter.pulsecount:
+        # Pulsecount reset (e.g. device restart)
+        if pulsecount == 0:
+            context.set_error(
+                f"S0PCM Reset detected for meter {meter_id}: Pulsecounters cleared. Restoring from total {meter.total}.",
+                category="serial",
+                level=logging.WARNING,
             )
-            meter.yesterday = meter.today
-            meter.today = 0
-            # Note: context.state.date update should ideally happen once.
-            # We'll update it here so subsequent meters in the same packet also see the change.
-            self.app_context.state.date = today
+        else:
+            context.set_error(
+                f"Pulsecount anomaly detected for meter {meter_id}: Stored pulsecount '{meter.pulsecount}' is higher than read '{pulsecount}'.",
+                category="serial",
+            )
 
-        # Check delta and update
-        if pulsecount > meter.pulsecount:
-            logger.debug(f"Pulsecount changed from '{meter.pulsecount}' to '{pulsecount}' for meter {meter_id}")
-            delta = pulsecount - meter.pulsecount
-            meter.pulsecount = pulsecount
-            meter.total += delta
-            meter.today += delta
+        # Note: We don't use the delta here if it reset, we just sync the pulsecount
+        # but we DO add what we received. Actually, if it reset to 0 and sends 10,
+        # we should add 10.
+        delta = pulsecount
+        meter.pulsecount = pulsecount
+        meter.total += delta
+        meter.today += delta
 
-        elif pulsecount < meter.pulsecount:
-            # Pulsecount reset (e.g. device restart)
-            if pulsecount == 0:
-                self.app_context.set_error(
-                    f"S0PCM Reset detected for meter {meter_id}: Pulsecounters cleared. Restoring from total {meter.total}.",
-                    category="serial",
-                    level=logging.WARNING,
-                )
-            else:
-                self.app_context.set_error(
-                    f"Pulsecount anomaly detected for meter {meter_id}: Stored pulsecount '{meter.pulsecount}' is higher than read '{pulsecount}'.",
-                    category="serial",
-                )
+    # Clamp to 32-bit signed integer max (matches HA number entity max: 2,147,483,647)
+    meter.total = min(meter.total, 2_147_483_647)
+    meter.today = min(meter.today, 2_147_483_647)
 
-            # Note: We don't use the delta here if it reset, we just sync the pulsecount
-            # but we DO add what we received. Actually, if it reset to 0 and sends 10,
-            # we should add 10.
-            delta = pulsecount
-            meter.pulsecount = pulsecount
-            meter.total += delta
-            meter.today += delta
 
-        # Clamp to 32-bit signed integer max (matches HA number entity max: 2,147,483,647)
-        meter.total = min(meter.total, 2_147_483_647)
-        meter.today = min(meter.today, 2_147_483_647)
+def _handle_data_packet(context: state_module.AppContext, datastr: str) -> None:
+    """
+    Parse data packet and update measurements in state.
 
-    def _read_loop(self, ser: serialx.BaseSerial) -> None:
-        """
-        Continuous read loop from serial port.
+    Args:
+        context: Application context.
+        datastr: Raw data packet string from serial port.
+    """
+    logger.debug(f"S0PCM Packet: '{datastr}'")
 
-        Args:
-            ser: The connected serial object.
-        """
-        while not self._stopper.is_set():
-            try:
-                datain = ser.readline(512)
-            except Exception as e:
-                self.app_context.set_error(f"Serialport read error: {type(e).__name__}: '{e}'", category="serial")
-                break  # Break to reconnect
+    try:
+        parsed_data = parse_s0pcm_packet(datastr)
+        interval = parsed_data["interval"]
+        meters = parsed_data["meters"]
+    except (ValueError, KeyError) as e:
+        context.set_error(f"Invalid Packet: {e}. Packet: '{datastr}'", category="serial")
+        return
 
-            if len(datain) == 0:
-                # Timeout
-                self.app_context.set_error("Serialport read timeout: Failed to read any data", category="serial")
-                break
+    for meter_id, data in meters.items():
+        _update_meter(context, meter_id, data["pulsecount"], data["pulses_in_interval"], interval)
 
-            try:
-                datastr = datain.decode("ascii").rstrip("\r\n")
-            except UnicodeDecodeError:
-                self.app_context.set_error(f"Failed to decode serial data: '{datain}'", category="serial")
-                continue
+    # Clear serial error
+    context.set_error(None, category="serial")
 
-            match datastr:
-                case str(s) if s.startswith(SerialPacketType.HEADER):
-                    self._handle_header(datastr)
-                case str(s) if s.startswith(SerialPacketType.DATA):
-                    self._handle_data_packet(datastr)
-                case "":
-                    logger.warning("Empty Packet received, this can happen during start-up")
-                case _:
-                    self.app_context.set_error(f"Invalid Packet: '{datastr}'", category="serial")
+    # Signal MQTT task that new data is available
+    context.trigger_event.set()
 
-    def run(self) -> None:
-        """Main thread execution."""
+
+async def _read_loop(context: state_module.AppContext, ser: serialx.BaseSerial) -> None:
+    """
+    Continuous read loop from serial port.
+
+    Args:
+        context: Application context.
+        ser: The connected async serial object.
+    """
+    while True:
         try:
-            # Wait for MQTT recovery to complete before starting to process serial data
-            logger.info("Serial Task: Waiting for MQTT/HA state recovery...")
-            self.app_context.recovery_event.wait()
-            logger.info("Serial Task: Recovery complete, starting serial read loop.")
+            datain = await ser.readline()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            context.set_error(f"Serialport read error: {type(e).__name__}: '{e}'", category="serial")
+            break  # Break to reconnect
 
-            while not self._stopper.is_set():
-                logger.debug(f"Opening serialport '{self.app_context.config.serial.port}'")
-                try:
-                    ser = serialx.serial_for_url(
-                        self.app_context.config.serial.port,
-                        baudrate=self.app_context.config.serial.baudrate,
-                        parity=self.app_context.config.serial.parity,
-                        stopbits=self.app_context.config.serial.stopbits,
-                        byte_size=self.app_context.config.serial.bytesize,
-                        read_timeout=self.app_context.config.serial.timeout,
-                        exclusive=True,
-                    )
-                    with ser:
-                        self._state.serialerror = 0
-                        logger.info(f"Connected to serialport '{self.app_context.config.serial.port}'")
-                        if not self._state.started:
-                            self._state.started = True
-                            logger.info(f"s0pcm-reader v{self.app_context.s0pcm_reader_version} started successfully")
-                        self._read_loop(ser)
-                except Exception as e:
-                    self._state.serialerror += 1
-                    self.app_context.set_error(
-                        f"Serialport connection failed: {type(e).__name__}: '{e}'", category="serial"
-                    )
-                    if self._state.serialerror == 1:
-                        self._log_available_ports()
-                    logger.error(f"Retry in {self.app_context.config.serial.connect_retry} seconds")
-                    time.sleep(self.app_context.config.serial.connect_retry)
-        except Exception:
-            logger.error("Fatal exception in Serial Task", exc_info=True)
-        finally:
-            self._stopper.set()
+        if len(datain) == 0:
+            # Timeout
+            context.set_error("Serialport read timeout: Failed to read any data", category="serial")
+            break
+
+        try:
+            datastr = datain.decode("ascii").rstrip("\r\n")
+        except UnicodeDecodeError:
+            context.set_error(f"Failed to decode serial data: '{datain}'", category="serial")
+            continue
+
+        match datastr:
+            case str(s) if s.startswith(SerialPacketType.HEADER):
+                _handle_header(context, datastr)
+            case str(s) if s.startswith(SerialPacketType.DATA):
+                _handle_data_packet(context, datastr)
+            case "":
+                logger.warning("Empty Packet received, this can happen during start-up")
+            case _:
+                context.set_error(f"Invalid Packet: '{datastr}'", category="serial")
+
+
+async def serial_task(context: state_module.AppContext) -> None:
+    """Main serial task coroutine."""
+    task_state = SerialTaskState()
+
+    try:
+        # Wait for MQTT recovery to complete before starting to process serial data
+        logger.info("Serial Task: Waiting for MQTT/HA state recovery...")
+        await context.recovery_event.wait()
+        logger.info("Serial Task: Recovery complete, starting serial read loop.")
+
+        while True:
+            logger.debug(f"Opening serialport '{context.config.serial.port}'")
+            try:
+                ser = serialx.async_serial_for_url(
+                    context.config.serial.port,
+                    baudrate=context.config.serial.baudrate,
+                    parity=context.config.serial.parity,
+                    stopbits=context.config.serial.stopbits,
+                    byte_size=context.config.serial.bytesize,
+                    read_timeout=context.config.serial.timeout,
+                    exclusive=True,
+                )
+                async with ser:
+                    task_state.serialerror = 0
+                    logger.info(f"Connected to serialport '{context.config.serial.port}'")
+                    if not task_state.started:
+                        task_state.started = True
+                        logger.info(f"s0pcm-reader v{context.s0pcm_reader_version} started successfully")
+                    await _read_loop(context, ser)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                task_state.serialerror += 1
+                context.set_error(f"Serialport connection failed: {type(e).__name__}: '{e}'", category="serial")
+                if task_state.serialerror == 1:
+                    _log_available_ports()
+                logger.error(f"Retry in {context.config.serial.connect_retry} seconds")
+                await asyncio.sleep(context.config.serial.connect_retry)
+    except asyncio.CancelledError:
+        logger.info("Serial Task: Cancelled, shutting down.")
+    except Exception:
+        logger.error("Fatal exception in Serial Task", exc_info=True)

--- a/rootfs/usr/src/state.py
+++ b/rootfs/usr/src/state.py
@@ -1,12 +1,12 @@
 """
 S0PCM Reader State
 
-Managed global state, threading locks, errors, and measurement data.
+Managed global state, events, errors, and measurement data.
 """
 
+import asyncio
 import datetime
 import logging
-import threading
 from typing import TYPE_CHECKING, Literal, Self
 
 from pydantic import BaseModel, Field
@@ -54,20 +54,19 @@ class AppState(BaseModel):
 
 class AppContext:
     """
-    Application context holding all shared state, locks, and events.
+    Application context holding all shared state and events.
 
-    This class is intended to be passed to components, reducing reliance on global state.
+    In the asyncio architecture, all access happens on the single event loop thread,
+    eliminating the need for locks or deep-copy snapshots.
     """
 
     def __init__(self):
-        # Threading & Events
-        self.lock = threading.RLock()
-        self.recovery_event = threading.Event()
-        self.trigger_event: threading.Event | None = None
+        # Asyncio Events
+        self.recovery_event = asyncio.Event()
+        self.trigger_event = asyncio.Event()
 
-        # Application State
+        # Application State (single copy — no snapshot needed in asyncio)
         self.state = AppState()
-        self.state_share = AppState()  # Snapshot for MQTT
 
         # Configuration
         self.config: ConfigModel | None = None
@@ -81,10 +80,6 @@ class AppContext:
         self.startup_time: str = datetime.datetime.now(datetime.UTC).isoformat()
         self.s0pcm_firmware: str = "Unknown"
         self.s0pcm_reader_version: str = "Unknown"
-
-    def register_trigger(self, event: threading.Event):
-        """Register the main trigger event for MQTT publishing."""
-        self.trigger_event = event
 
     def set_error(
         self,
@@ -120,16 +115,13 @@ class AppContext:
             if self.lasterror_mqtt:
                 errors.append(self.lasterror_mqtt)
 
-            new_error = " | ".join(errors) if errors else None
-
-            with self.lock:
-                self.lasterror_share = new_error
+            self.lasterror_share = " | ".join(errors) if errors else None
 
             if message:
                 log_level = level if level is not None else logging.ERROR
                 logger.log(log_level, f"[{category.upper()}] {message}")
 
-            if trigger_event and self.trigger_event:
+            if trigger_event:
                 self.trigger_event.set()
 
 

--- a/rootfs/usr/src/utils.py
+++ b/rootfs/usr/src/utils.py
@@ -4,6 +4,7 @@ S0PCM Reader Utilities
 Helper functions for version detection and Home Assistant Supervisor API access.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 type JsonDict = dict[str, Any]
 
 
-def get_version() -> str:
+async def get_version() -> str:
     """
     Get the S0PCM Reader version.
 
@@ -49,19 +50,25 @@ def get_version() -> str:
         Path("./config.yaml"),
     ]
 
-    for path in search_paths:
-        if path.exists():
-            try:
-                with path.open() as f:
-                    if (config_yaml := yaml.safe_load(f)) and "version" in config_yaml:
-                        return f"{config_yaml['version']} (local)"
-            except OSError, yaml.YAMLError:
-                pass
+    def _read_version():
+        for path in search_paths:
+            if path.exists():
+                try:
+                    with path.open() as f:
+                        if (config_yaml := yaml.safe_load(f)) and "version" in config_yaml:
+                            return f"{config_yaml['version']} (local)"
+                except OSError, yaml.YAMLError:
+                    pass
+        return None
+
+    res = await asyncio.to_thread(_read_version)
+    if res:
+        return res
 
     return "dev"
 
 
-def get_supervisor_config(service: str) -> JsonDict:
+async def get_supervisor_config(service: str) -> JsonDict:
     """
     Fetch service configuration from the Home Assistant Supervisor API.
 
@@ -79,10 +86,15 @@ def get_supervisor_config(service: str) -> JsonDict:
     headers = {"Authorization": f"Bearer {token}"}
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=5) as response:
-            if response.status == 200:
-                data = json.loads(response.read().decode())
-                return data.get("data", {})
+
+        def _fetch():
+            with urllib.request.urlopen(req, timeout=5) as response:
+                if response.status == 200:
+                    data = json.loads(response.read().decode())
+                    return data.get("data", {})
+            return {}
+
+        return await asyncio.to_thread(_fetch)
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
         logger.debug(f"Supervisor API discovery for {service} failed: {e}")
     return {}
@@ -152,7 +164,7 @@ def parse_localized_number(value_str: str) -> float | None:
         return None
 
 
-def get_ha_core_version() -> str | None:
+async def get_ha_core_version() -> str | None:
     """Fetch the Home Assistant Core version from the Supervisor API."""
     token = os.getenv("SUPERVISOR_TOKEN")
     if not token:
@@ -162,10 +174,15 @@ def get_ha_core_version() -> str | None:
     headers = {"Authorization": f"Bearer {token}"}
     try:
         req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=5) as response:
-            if response.status == 200:
-                data = json.loads(response.read().decode())
-                return data.get("data", {}).get("version")
+
+        def _fetch():
+            with urllib.request.urlopen(req, timeout=5) as response:
+                if response.status == 200:
+                    data = json.loads(response.read().decode())
+                    return data.get("data", {}).get("version")
+            return None
+
+        return await asyncio.to_thread(_fetch)
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
         logger.debug(f"Supervisor API /core/info failed: {e}")
     return None

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -15,7 +15,7 @@ WORKDIR /workspace
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 # Install all deps (prod + test group)
 COPY pyproject.toml uv.lock ./

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -2,7 +2,7 @@
 # This container provides an isolated environment for running tests
 
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/tests/README.md
+++ b/tests/README.md
@@ -124,12 +124,10 @@ The `docker-test.sh` (Linux) and `docker-test.ps1` (Windows) scripts perform the
 If running in a strictly read-only environment, the cache provider is disabled via `pytest.ini` (`-p no:cacheprovider`) to prevent `PytestCacheWarning`.
 
 ### Tests Hanging
-Hanging tests usually indicate an unstopped thread. Ensure all `threading.Event` objects (like `stopper`) are set during cleanup:
-```python
-stopper.set()
-trigger.set()
-thread.join(timeout=5)
-```
+Hanging tests usually indicate an unstopped asynchronous task or a coroutine that is running indefinitely (e.g., an infinite loop in a background task). Ensure:
+1. Any background loop has a clean exit condition or handles `asyncio.CancelledError` properly.
+2. Background tasks created on the event loop (e.g., via `asyncio.create_task` or within a `TaskGroup`) are cancelled and awaited during test cleanup.
+3. Tests use `pytest-timeout` to fail automatically if they exceed a specific duration, rather than hanging indefinitely.
 
 ### Script Execution Policy (Windows)
 If `.ps1` scripts are blocked, run:
@@ -138,4 +136,4 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 ```
 
 ---
-*Last updated: 2026-05-02*
+*Last updated: 2026-06-14*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,12 @@
 Shared pytest fixtures for S0PCM Reader tests.
 """
 
+import asyncio
 import json
 import os
 import sys
 import tempfile
-import threading
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -21,15 +21,9 @@ import state as state_module
 def setup_s0pcm_globals():
     """Ensure global variables expected by s0pcm_reader are initialized."""
     # Lazy import to avoid coverage issues
-    import s0pcm_reader
 
     # Use the real context from state_module
-    context = state_module.get_context()
-    # Register trigger with context
-    trigger = threading.Event()
-    context.register_trigger(trigger)
-    # Expose trigger on s0pcm_reader module if main tests expect it
-    s0pcm_reader.trigger = trigger
+    state_module.get_context()
 
 
 @pytest.fixture
@@ -39,10 +33,13 @@ def mock_serial(mocker):
 
 
 @pytest.fixture
-def mock_mqtt_client(mocker):
-    """Mock paho.mqtt.client.Client class."""
-    mock = MagicMock()
-    mocker.patch("paho.mqtt.client.Client", return_value=mock)
+def mock_aiomqtt_client():
+    """Create a mock aiomqtt.Client for testing."""
+    mock = AsyncMock()
+    mock.publish = AsyncMock()
+    mock.subscribe = AsyncMock()
+    mock.unsubscribe = AsyncMock()
+    mock.messages = AsyncMock()
     return mock
 
 
@@ -77,33 +74,6 @@ def mock_options_file(temp_config_dir, sample_options):
     with open(options_path, "w") as f:
         json.dump(sample_options, f)
     return options_path
-
-
-@pytest.fixture
-def threading_helpers():
-    """Helper utilities for testing threaded code."""
-
-    class ThreadingHelpers:
-        @staticmethod
-        def create_events():
-            """Create trigger and stopper events."""
-            return threading.Event(), threading.Event()
-
-        @staticmethod
-        def wait_for_thread(thread, timeout=5):
-            """Wait for a thread to finish with timeout."""
-            thread.join(timeout=timeout)
-            return not thread.is_alive()
-
-        @staticmethod
-        def stop_thread(thread, stopper, trigger, timeout=5):
-            """Stop a thread gracefully."""
-            stopper.set()
-            trigger.set()
-            thread.join(timeout=timeout)
-            return not thread.is_alive()
-
-    return ThreadingHelpers()
 
 
 @pytest.fixture
@@ -156,12 +126,13 @@ def reset_global_state():
     """Reset global state before each test."""
     context = state_module.get_context()
     # Use context methods to clear state
-    with context.lock:
-        context.state.reset_state()
-        context.state_share.reset_state()
+    context.state.reset_state()
     context.lasterror_serial = None
     context.lasterror_mqtt = None
     context.lasterror_share = None
     context.config = None
     context.s0pcm_firmware = "Unknown"
+    # Reset asyncio events
+    context.recovery_event = asyncio.Event()
+    context.trigger_event = asyncio.Event()
     yield

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,7 +17,7 @@ def make_test_config(**mqtt_overrides) -> ConfigModel:
         "password": "test_pass",
         "base_topic": "s0pcmreader",
         "client_id": None,
-        "version": 5,
+        "version": "5.0",
         "retain": True,
         "split_topic": True,
         "connect_retry": 1,

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -4,7 +4,7 @@ WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --system --no-cache -r - && \

--- a/tests/standalone/simulator/Dockerfile
+++ b/tests/standalone/simulator/Dockerfile
@@ -1,4 +1,4 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 COPY tests/standalone/simulator/simulator.py /simulator.py
 CMD ["python3", "-u", "/simulator.py"]

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
 
 # Use the project's lock file for paho-mqtt version consistency
 COPY pyproject.toml uv.lock ./

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -1,5 +1,5 @@
 # 3.14-alpine
-FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.14-alpine@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f
 WORKDIR /app
 
 # Install uv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,6 +161,26 @@ class TestAutoDetectSerialPort:
         port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
 
+    async def test_auto_detect_arduino_vid(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyACM99"
+        mock_port.vid = 0x2341
+        mock_port.manufacturer = "Arduino LLC"
+        mock_port.description = "Arduino Leonardo"
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = await config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyACM99"
+
+    async def test_auto_detect_arduino_name(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-Arduino_LLC_Arduino_Leonardo-if00-port0"
+        mock_port.vid = 0x1234
+        mock_port.manufacturer = None
+        mock_port.description = None
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = await config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-Arduino_LLC_Arduino_Leonardo-if00-port0"
+
     async def test_auto_detect_generic_usb(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ import json
 import os
 from pathlib import Path
 import sys
-import threading
 from unittest.mock import patch
 
 import pytest
@@ -81,22 +80,20 @@ class TestConfigEdgeCases:
 class TestErrorHandling:
     def test_set_error_behavior(self, mocker):
         """Test SetError sets the shared error and triggers the event, including clearing."""
-        trigger = threading.Event()
         context = state_module.get_context()
-        context.register_trigger(trigger)
         context.lasterror_share = None
-        context.lasterror_serial = None  # Reset internal state too
+        context.lasterror_serial = None
         context.lasterror_mqtt = None
 
         # 1. Set error
         context.set_error("Test Error")
         assert context.lasterror_share == "Test Error"
-        assert trigger.is_set()
+        assert context.trigger_event.is_set()
 
-        trigger.clear()
+        context.trigger_event.clear()
         context.set_error(None)
         assert context.lasterror_share is None
-        assert trigger.is_set()
+        assert context.trigger_event.is_set()
 
 
 class TestConfigCoverage:
@@ -129,6 +126,12 @@ class TestConfigCoverage:
         model = config_module.read_config()
         assert model.mqtt.base_topic == "s0pcmreader"
         assert model.log.level == "INFO"
+
+    def test_read_config_mqtt_version_string(self):
+        """Test that MQTT version is stored as a string."""
+        model = config_module.read_config()
+        assert model.mqtt.version == "5.0"
+        assert isinstance(model.mqtt.version, str)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import json
 import os
 from pathlib import Path
 import sys
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -21,18 +21,18 @@ def setup_config_test_env():
 
 
 class TestConfigLoading:
-    def test_load_default_config(self, mocker):
+    async def test_load_default_config(self, mocker):
         # Mock Path.exists and Path.read_text for safer modern python testing
         mocker.patch.object(Path, "exists", return_value=False)
         context = state_module.get_context()
-        context.config = config_module.read_config()
+        context.config = await config_module.read_config()
         assert context.config.mqtt.host == "127.0.0.1"
 
-    def test_load_config_from_options(self, sample_options, mocker):
+    async def test_load_config_from_options(self, sample_options, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         mocker.patch.object(Path, "read_text", return_value=json.dumps(sample_options))
         context = state_module.get_context()
-        context.config = config_module.read_config()
+        context.config = await config_module.read_config()
         assert context.config.mqtt.host == sample_options["mqtt"]["host"]
 
 
@@ -45,23 +45,23 @@ class TestCLI:
 
 
 class TestConfigEdgeCases:
-    def test_tls_path_join(self, mocker):
+    async def test_tls_path_join(self, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         mocker.patch.object(Path, "read_text", return_value=json.dumps({"security": {"tls": True, "tls_ca": "ca.crt"}}))
         context = state_module.get_context()
-        context.config = config_module.read_config(config_dir=Path("/data/"))
+        context.config = await config_module.read_config(config_dir=Path("/data/"))
         expected_path = os.path.normpath("data/ca.crt")
         actual_path = os.path.normpath(context.config.mqtt.tls_ca)
         assert expected_path in actual_path
 
-    def test_password_redaction(self, mocker):
+    async def test_password_redaction(self, mocker):
         mocker.patch.object(Path, "exists", return_value=True)
         # Test 1: Password set
         mocker.patch.object(
             Path, "read_text", return_value=json.dumps({"mqtt": {"password": "secret", "username": "admin"}})
         )
         with patch("logging.Logger.debug") as mock_debug:
-            config_module.read_config()
+            await config_module.read_config()
             log_str = str(mock_debug.call_args[0][0])
             assert "**********" in log_str
             assert "secret" not in log_str
@@ -70,7 +70,7 @@ class TestConfigEdgeCases:
         # Test 2: Password None
         mocker.patch.object(Path, "read_text", return_value=json.dumps({}))
         with patch("logging.Logger.debug") as mock_debug:
-            config_module.read_config()
+            await config_module.read_config()
             log_str = str(mock_debug.call_args[0][0])
             # Check for None explicitly
             assert "'password': None" in log_str
@@ -97,71 +97,71 @@ class TestErrorHandling:
 
 
 class TestConfigCoverage:
-    def test_read_config_options_exception(self):
+    async def test_read_config_options_exception(self):
         """Test exception handling during options.json load (lines 118-119)."""
         with (
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.read_text", side_effect=Exception("Read Error")),
             patch("config.logger.error") as mock_logger,
         ):
-            config_module.read_config()
+            await config_module.read_config()
             assert mock_logger.called
             assert any("Failed to load" in str(c) for c in mock_logger.call_args_list)
 
-    def test_read_config_mqtt_discovery_log(self, mocker):
+    async def test_read_config_mqtt_discovery_log(self, mocker):
         """Test logging when MQTT service discovery is used (line 126)."""
         # Mock get_supervisor_config to return data
         with (
-            patch("config.get_supervisor_config", return_value={"host": "1.2.3.4"}),
+            patch("config.get_supervisor_config", new_callable=AsyncMock, return_value={"host": "1.2.3.4"}),
             patch("config.logger.info") as mock_logger,
         ):
-            config_module.read_config()
+            await config_module.read_config()
 
             # One of the calls should be the discovery message
             found = any("Using MQTT service discovery" in str(c) for c in mock_logger.call_args_list)
             assert found
 
-    def test_read_config_returns_model(self):
+    async def test_read_config_returns_model(self):
         """Test that read_config returns a ConfigModel directly."""
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.mqtt.base_topic == "s0pcmreader"
         assert model.log.level == "INFO"
 
-    def test_read_config_mqtt_version_string(self):
+    async def test_read_config_mqtt_version_string(self):
         """Test that MQTT version is stored as a string."""
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.mqtt.version == "5.0"
         assert isinstance(model.mqtt.version, str)
 
 
 class TestAutoDetectSerialPort:
-    def test_auto_detect_no_ports(self, mocker):
+    async def test_auto_detect_no_ports(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         with patch("config.logger.warning") as mock_warn:
-            port = config_module._auto_detect_serial_port()
+            port = await config_module._auto_detect_serial_port()
             assert port == "/dev/ttyACM0"
             mock_warn.assert_called_once()
             assert "No serial ports detected" in mock_warn.call_args[0][0]
 
-    def test_auto_detect_ch340_vid(self, mocker):
+    async def test_auto_detect_ch340_vid(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/ttyUSB99"
         mock_port.vid = 0x1A86
         mock_port.manufacturer = "CH340 Manufacturer"
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/ttyUSB99"
 
-    def test_auto_detect_ch340_name(self, mocker):
+    async def test_auto_detect_ch340_name(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
         mock_port.vid = 0x1234
         mock_port.manufacturer = None
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
 
-    def test_auto_detect_generic_usb(self, mocker):
+    async def test_auto_detect_generic_usb(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
         mock_port.vid = 0x0403
@@ -169,10 +169,10 @@ class TestAutoDetectSerialPort:
         mock_port.description = "FTDI USB Serial"
 
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
 
-    def test_auto_detect_fallback_first(self, mocker):
+    async def test_auto_detect_fallback_first(self, mocker):
         mock_port = mocker.MagicMock()
         mock_port.device = "/dev/ttyS0"
         mock_port.vid = None
@@ -180,31 +180,31 @@ class TestAutoDetectSerialPort:
         mock_port.description = "Standard Serial Port"
 
         mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
-        port = config_module._auto_detect_serial_port()
+        port = await config_module._auto_detect_serial_port()
         assert port == "/dev/ttyS0"
 
-    def test_auto_detect_exception(self, mocker):
+    async def test_auto_detect_exception(self, mocker):
         mocker.patch("serialx.list_serial_ports", side_effect=RuntimeError("Scan error"))
         with patch("config.logger.error") as mock_error:
-            port = config_module._auto_detect_serial_port()
+            port = await config_module._auto_detect_serial_port()
             assert port == "/dev/ttyACM0"
             mock_error.assert_called_once()
             assert "Exception during port scan" in mock_error.call_args[0][0]
 
-    def test_read_config_triggers_auto_detect(self, mocker):
+    async def test_read_config_triggers_auto_detect(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         mocker.patch("pathlib.Path.exists", return_value=True)
         mocker.patch("pathlib.Path.read_text", return_value=json.dumps({"device": None}))
 
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
-    def test_read_config_triggers_auto_detect_missing_key(self, mocker):
+    async def test_read_config_triggers_auto_detect_missing_key(self, mocker):
         mocker.patch("serialx.list_serial_ports", return_value=[])
         mocker.patch("pathlib.Path.exists", return_value=True)
         mocker.patch("pathlib.Path.read_text", return_value=json.dumps({}))
 
-        model = config_module.read_config()
+        model = await config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,7 +106,7 @@ class TestConfigCoverage:
         ):
             config_module.read_config()
             assert mock_logger.called
-            assert "Failed to load" in mock_logger.call_args[0][0]
+            assert any("Failed to load" in str(c) for c in mock_logger.call_args_list)
 
     def test_read_config_mqtt_discovery_log(self, mocker):
         """Test logging when MQTT service discovery is used (line 126)."""
@@ -132,6 +132,72 @@ class TestConfigCoverage:
         model = config_module.read_config()
         assert model.mqtt.version == "5.0"
         assert isinstance(model.mqtt.version, str)
+
+
+class TestAutoDetectSerialPort:
+    def test_auto_detect_no_ports(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        with patch("config.logger.warning") as mock_warn:
+            port = config_module._auto_detect_serial_port()
+            assert port == "/dev/ttyACM0"
+            mock_warn.assert_called_once()
+            assert "No serial ports detected" in mock_warn.call_args[0][0]
+
+    def test_auto_detect_ch340_vid(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyUSB99"
+        mock_port.vid = 0x1A86
+        mock_port.manufacturer = "CH340 Manufacturer"
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyUSB99"
+
+    def test_auto_detect_ch340_name(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
+        mock_port.vid = 0x1234
+        mock_port.manufacturer = None
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0"
+
+    def test_auto_detect_generic_usb(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
+        mock_port.vid = 0x0403
+        mock_port.manufacturer = "FTDI"
+        mock_port.description = "FTDI USB Serial"
+
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/serial/by-id/usb-FTDI_FT232R-if00-port0"
+
+    def test_auto_detect_fallback_first(self, mocker):
+        mock_port = mocker.MagicMock()
+        mock_port.device = "/dev/ttyS0"
+        mock_port.vid = None
+        mock_port.manufacturer = None
+        mock_port.description = "Standard Serial Port"
+
+        mocker.patch("serialx.list_serial_ports", return_value=[mock_port])
+        port = config_module._auto_detect_serial_port()
+        assert port == "/dev/ttyS0"
+
+    def test_auto_detect_exception(self, mocker):
+        mocker.patch("serialx.list_serial_ports", side_effect=RuntimeError("Scan error"))
+        with patch("config.logger.error") as mock_error:
+            port = config_module._auto_detect_serial_port()
+            assert port == "/dev/ttyACM0"
+            mock_error.assert_called_once()
+            assert "Exception during port scan" in mock_error.call_args[0][0]
+
+    def test_read_config_triggers_auto_detect(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        mocker.patch("pathlib.Path.exists", return_value=True)
+        mocker.patch("pathlib.Path.read_text", return_value=json.dumps({"device": None}))
+
+        model = config_module.read_config()
+        assert model.serial.port == "/dev/ttyACM0"
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,6 +199,14 @@ class TestAutoDetectSerialPort:
         model = config_module.read_config()
         assert model.serial.port == "/dev/ttyACM0"
 
+    def test_read_config_triggers_auto_detect_missing_key(self, mocker):
+        mocker.patch("serialx.list_serial_ports", return_value=[])
+        mocker.patch("pathlib.Path.exists", return_value=True)
+        mocker.patch("pathlib.Path.read_text", return_value=json.dumps({}))
+
+        model = config_module.read_config()
+        assert model.serial.port == "/dev/ttyACM0"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,7 +3,7 @@ Tests for discovery module (discovery.py).
 """
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from helpers import make_test_config
 
@@ -11,81 +11,83 @@ import state as state_module
 from state import MeterState
 
 
-def test_send_global_discovery_new_ha(mocker):
+async def test_send_global_discovery_new_ha(mocker):
     """Test global discovery message publishing with HA >= 2025.5.0."""
     import discovery
 
-    mock_mqttc = MagicMock()
+    mock_client = AsyncMock()
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
     mocker.patch("utils.get_ha_core_version", return_value="2025.5.0")
 
-    discovery.send_global_discovery(mock_mqttc, context)
+    await discovery.send_global_discovery(mock_client, context)
 
     # Core check: Was something published?
-    assert mock_mqttc.publish.called
+    assert mock_client.publish.called
 
     # Check status topic
     status_call = [
-        c for c in mock_mqttc.publish.call_args_list if "binary_sensor/s0pcm/s0pcm_s0pcm_status/config" in str(c)
+        c for c in mock_client.publish.call_args_list if "binary_sensor/s0pcm/s0pcm_s0pcm_status/config" in c.args[0]
     ]
     assert status_call
-    payload = json.loads(status_call[0][0][1])
+    payload = json.loads(status_call[0].args[1])
     assert payload["name"] == "S0PCM Reader Status"
     assert payload["device"]["sw_version"] == "3.0.0"
 
     # Check startup_time sensor
     startup_call = [
-        c for c in mock_mqttc.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_startup_time/config" in str(c)
+        c for c in mock_client.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_startup_time/config" in c.args[0]
     ]
     assert startup_call
-    startup_payload = json.loads(startup_call[0][0][1])
+    startup_payload = json.loads(startup_call[0].args[1])
     assert startup_payload["device_class"] == "uptime"
     assert startup_payload["icon"] == "mdi:clock-start"
 
 
-def test_send_global_discovery_old_ha(mocker):
+async def test_send_global_discovery_old_ha(mocker):
     """Test global discovery message publishing with HA < 2025.5.0."""
     import discovery
 
-    mock_mqttc = MagicMock()
+    mock_client = AsyncMock()
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
     mocker.patch("utils.get_ha_core_version", return_value="2024.12.0")
 
-    discovery.send_global_discovery(mock_mqttc, context)
+    await discovery.send_global_discovery(mock_client, context)
 
     # Check startup_time sensor fallback
     startup_call = [
-        c for c in mock_mqttc.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_startup_time/config" in str(c)
+        c for c in mock_client.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_startup_time/config" in c.args[0]
     ]
     assert startup_call
-    startup_payload = json.loads(startup_call[0][0][1])
+    startup_payload = json.loads(startup_call[0].args[1])
     assert startup_payload["device_class"] == "timestamp"
     assert startup_payload["icon"] == "mdi:clock-outline"
 
 
-def test_send_meter_discovery(mocker):
+async def test_send_meter_discovery(mocker):
     """Test meter discovery message publishing."""
     import discovery
 
-    mock_mqttc = MagicMock()
+    mock_client = AsyncMock()
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm")
 
     meter_state = MeterState(name="Water")
-    instancename = discovery.send_meter_discovery(mock_mqttc, context, 1, meter_state)
+    instancename = await discovery.send_meter_discovery(mock_client, context, 1, meter_state)
 
     assert instancename == "Water"
 
     # Check total sensor discovery
-    total_call = [c for c in mock_mqttc.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_1_total/config" in str(c)]
+    total_call = [
+        c for c in mock_client.publish.call_args_list if "sensor/s0pcm/s0pcm_s0pcm_1_total/config" in c.args[0]
+    ]
     assert total_call
-    payload = json.loads(total_call[-1][0][1])  # Get last call for this topic
+    payload = json.loads(total_call[-1].args[1])  # Get last call for this topic
     assert payload["name"] == "Water Total"
     assert payload["state_class"] == "total_increasing"
     assert payload["availability_topic"] == "s0pcm/status"
@@ -95,42 +97,42 @@ def test_send_meter_discovery(mocker):
     # Verify purge of obsolete diagnostic sensors (PPS and Activity)
     activity_clear = [
         c
-        for c in mock_mqttc.publish.call_args_list
-        if "binary_sensor/s0pcm/s0pcm_s0pcm_1_activity/config" in str(c) and c[0][1] == ""
+        for c in mock_client.publish.call_args_list
+        if "binary_sensor/s0pcm/s0pcm_s0pcm_1_activity/config" in c.args[0] and c.args[1] == ""
     ]
     pps_clear = [
         c
-        for c in mock_mqttc.publish.call_args_list
-        if "sensor/s0pcm/s0pcm_s0pcm_1_pps/config" in str(c) and c[0][1] == ""
+        for c in mock_client.publish.call_args_list
+        if "sensor/s0pcm/s0pcm_s0pcm_1_pps/config" in c.args[0] and c.args[1] == ""
     ]
     assert activity_clear
     assert pps_clear
 
 
-def test_discovery_disabled(mocker):
+async def test_discovery_disabled(mocker):
     """Test behavior when discovery is disabled."""
     import discovery
 
-    mock_mqttc = MagicMock()
+    mock_client = AsyncMock()
     context = state_module.get_context()
     context.config = make_test_config(discovery=False)
 
-    discovery.send_global_discovery(mock_mqttc, context)
-    assert not mock_mqttc.publish.called
+    await discovery.send_global_discovery(mock_client, context)
+    assert not mock_client.publish.called
 
-    result = discovery.send_meter_discovery(mock_mqttc, context, 1, MeterState())
+    result = await discovery.send_meter_discovery(mock_client, context, 1, MeterState())
     assert result is None
-    assert not mock_mqttc.publish.called
+    assert not mock_client.publish.called
 
 
-def test_send_global_discovery_with_units(mocker):
+async def test_send_global_discovery_with_units(mocker):
     """Test send_global_discovery with custom diagnostics including units (line 93)."""
     import discovery
 
     context = state_module.get_context()
     context.s0pcm_reader_version = "3.0.0"
     context.config = make_test_config(base_topic="s0pcm")
-    mqttc = MagicMock()
+    mock_client = AsyncMock()
 
     # Custom diagnostics with all fields including 'unit'
     custom_diags = [
@@ -144,12 +146,10 @@ def test_send_global_discovery_with_units(mocker):
     ]
 
     with patch("discovery.GLOBAL_DIAGNOSTICS", custom_diags):
-        discovery.send_global_discovery(mqttc, context)
+        await discovery.send_global_discovery(mock_client, context)
 
     # Verify the published config
-    # topic: homeassistant/sensor/s0pcm/s0pcm_s0pcm_temp/config
-    # find the call
-    config_call = next(c for c in mqttc.publish.call_args_list if "temp" in c.args[0])
+    config_call = next(c for c in mock_client.publish.call_args_list if "temp" in c.args[0])
     payload = json.loads(config_call.args[1])
 
     assert payload["unit_of_measurement"] == "°C"
@@ -157,37 +157,37 @@ def test_send_global_discovery_with_units(mocker):
     assert payload["name"] == "S0PCM Reader Temperature"
 
 
-def test_send_meter_discovery_split_topic():
+async def test_send_meter_discovery_split_topic():
     """Test meter discovery with split_topic enabled."""
     import discovery
 
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm", split_topic=True)
-    mqttc = MagicMock()
+    mock_client = AsyncMock()
 
-    discovery.send_meter_discovery(mqttc, context, 1, MeterState(name="test"))
+    await discovery.send_meter_discovery(mock_client, context, 1, MeterState(name="test"))
 
     # Find the 'total' config message
-    total_call = next(c for c in mqttc.publish.call_args_list if "total" in c.args[0] and "{" in str(c.args[1]))
+    total_call = next(c for c in mock_client.publish.call_args_list if "total" in c.args[0] and "{" in str(c.args[1]))
 
     payload = json.loads(total_call.args[1])
     assert payload["state_topic"] == "s0pcm/test/total"
 
 
-def test_cleanup_meter_discovery_enabled():
+async def test_cleanup_meter_discovery_enabled():
     """Test cleanup_meter_discovery with discovery enabled (lines 199-217)."""
     import discovery
 
     context = state_module.get_context()
     context.config = make_test_config()
-    mqttc = MagicMock()
+    mock_client = AsyncMock()
 
-    discovery.cleanup_meter_discovery(mqttc, context, 5)
+    await discovery.cleanup_meter_discovery(mock_client, context, 5)
 
     # Should publish empty payloads to clear discovery
-    assert mqttc.publish.call_count > 0
+    assert mock_client.publish.call_count > 0
     # Check that it published to sensor topics
-    topics = [call[0][0] for call in mqttc.publish.call_args_list]
+    topics = [call[0][0] for call in mock_client.publish.call_args_list]
     assert any("sensor" in t for t in topics)
     assert any("text" in t for t in topics)
     assert any("number" in t for t in topics)
@@ -196,31 +196,31 @@ def test_cleanup_meter_discovery_enabled():
     assert any("sensor" in t and "pps" in t for t in topics)
 
 
-def test_cleanup_meter_discovery_disabled():
+async def test_cleanup_meter_discovery_disabled():
     """Test that cleanup does nothing if discovery is disabled."""
     import discovery
 
     context = state_module.get_context()
     context.config = make_test_config(discovery=False)
-    mqttc = MagicMock()
+    mock_client = AsyncMock()
 
-    discovery.cleanup_meter_discovery(mqttc, context, 1)
-    mqttc.publish.assert_not_called()
+    await discovery.cleanup_meter_discovery(mock_client, context, 1)
+    mock_client.publish.assert_not_called()
 
 
-def test_send_meter_discovery_combined_topic(mocker):
+async def test_send_meter_discovery_combined_topic(mocker):
     """Test discovery payload when split_topic is False."""
     import discovery
 
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm", split_topic=False)
-    mock_mqtt = MagicMock()
+    mock_client = AsyncMock()
 
-    discovery.send_meter_discovery(mock_mqtt, context, 1, MeterState(name="Combined"))
+    await discovery.send_meter_discovery(mock_client, context, 1, MeterState(name="Combined"))
 
     # Check if value_template is correctly set in one of the publish calls
     found_template = False
-    for call in mock_mqtt.publish.call_args_list:
+    for call in mock_client.publish.call_args_list:
         payload_str = call.args[1]
         if payload_str:
             payload = json.loads(payload_str)
@@ -230,21 +230,21 @@ def test_send_meter_discovery_combined_topic(mocker):
     assert found_template is True
 
 
-def test_send_meter_discovery_sanitizes_name():
+async def test_send_meter_discovery_sanitizes_name():
     """Test that MQTT special characters in meter names are stripped from topics."""
     import discovery
 
     context = state_module.get_context()
     context.config = make_test_config(base_topic="s0pcm")
-    mqttc = MagicMock()
+    mock_client = AsyncMock()
 
     meter_state = MeterState(name="My/Water+Meter#1")
-    instancename = discovery.send_meter_discovery(mqttc, context, 1, meter_state)
+    instancename = await discovery.send_meter_discovery(mock_client, context, 1, meter_state)
 
     assert instancename == "MyWaterMeter1"
 
     # Verify no topics contain MQTT special characters from the name
-    for call in mqttc.publish.call_args_list:
+    for call in mock_client.publish.call_args_list:
         topic = call.args[0]
         if "MyWaterMeter1" in topic:
             assert "/" not in topic.split("s0pcm/")[-1].replace("MyWaterMeter1/", "MyWaterMeter1")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -20,7 +20,7 @@ async def test_send_global_discovery_new_ha(mocker):
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
-    mocker.patch("utils.get_ha_core_version", return_value="2025.5.0")
+    mocker.patch("utils.get_ha_core_version", new_callable=AsyncMock, return_value="2025.5.0")
 
     await discovery.send_global_discovery(mock_client, context)
 
@@ -55,7 +55,7 @@ async def test_send_global_discovery_old_ha(mocker):
     context.config = make_test_config(base_topic="s0pcm")
     context.s0pcm_reader_version = "3.0.0"
 
-    mocker.patch("utils.get_ha_core_version", return_value="2024.12.0")
+    mocker.patch("utils.get_ha_core_version", new_callable=AsyncMock, return_value="2024.12.0")
 
     await discovery.send_global_discovery(mock_client, context)
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -90,3 +90,12 @@ class TestIsProcessRunning:
         # Reset for second check
         mock_iterdir.return_value = _mock_proc_entries(["42"], cmdline_data=cmdline_data)
         assert is_process_running("other_app.py") is False
+
+    @patch("healthcheck.os.getpid", return_value=1)
+    @patch("healthcheck.Path.iterdir")
+    def test_rejects_non_python_process(self, mock_iterdir, mock_getpid):
+        """Rejects processes that reference the script name but aren't Python (e.g. grep)."""
+        cmdline_data = b"grep\x00s0pcm_reader.py\x00"
+        mock_iterdir.return_value = _mock_proc_entries(["42"], cmdline_data=cmdline_data)
+
+        assert is_process_running() is False

--- a/tests/test_mqtt_handler.py
+++ b/tests/test_mqtt_handler.py
@@ -509,6 +509,227 @@ class TestMQTTAdditionalCoverage:
         assert _resolve_meter_id(mqtt_context, "NonExistent") is None
         assert _resolve_meter_id(mqtt_context, "1") == 1  # Numeric ID
 
+    async def test_message_listener(self, mqtt_context, mocker):
+        """Test _message_listener processes set/name commands."""
+        from mqtt_handler import MqttTaskState, _message_listener
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+
+        # Create mock messages
+        msg1 = MagicMock()
+        msg1.topic = "s0pcmreader/1/total/set"
+        msg1.payload = b"2000"
+
+        msg2 = MagicMock()
+        msg2.topic = "s0pcmreader/2/name/set"
+        msg2.payload = b"Gas"
+
+        async def mock_messages():
+            yield msg1
+            yield msg2
+
+        mock_client.messages = mock_messages()
+
+        mock_handle_set = mocker.patch("mqtt_handler._handle_set_command", new_callable=AsyncMock)
+        mock_handle_name_set = mocker.patch("mqtt_handler._handle_name_set", new_callable=AsyncMock)
+
+        await _message_listener(mqtt_context, mock_client, task_state)
+
+        mock_handle_set.assert_called_once_with(mqtt_context, "s0pcmreader/1/total/set", b"2000")
+        mock_handle_name_set.assert_called_once_with(
+            mqtt_context, mock_client, task_state, "s0pcmreader/2/name/set", b"Gas"
+        )
+
+    async def test_publish_loop_global_discovery(self, mqtt_context, mocker):
+        """Test that _publish_loop sends global discovery and cleans up ghost meters."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+
+        mock_send_global = mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mock_cleanup = mocker.patch("mqtt_handler.discovery.cleanup_meter_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock)
+
+        # Make trigger event fire once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        assert mock_send_global.call_count == 1
+        assert mock_cleanup.call_count == 5
+        assert task_state.global_discovery_sent is True
+
+    async def test_publish_loop_delayed_clear(self, mqtt_context, mocker):
+        """Test that delayed_clear background task clears the MQTT error."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+        task_state.global_discovery_sent = True
+
+        # Set error message on context
+        mqtt_context.set_error("MQTT Connect Fail", category="mqtt", trigger_event=False)
+
+        # Mock asyncio.sleep dynamically using original sleep to yield control properly
+        original_sleep = asyncio.sleep
+
+        async def mock_sleep(delay, result=None):
+            await original_sleep(0)
+
+        mocker.patch("asyncio.sleep", new=mock_sleep)
+
+        # Trigger event once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        # Verify the error was published
+        mock_client.publish.assert_any_call("s0pcmreader/error", "MQTT Connect Fail", retain=True)
+
+        # Ensure the background task completed and called set_error(None)
+        await original_sleep(0.05)  # yield control so task executes
+
+        assert mqtt_context.lasterror_mqtt is None
+
+    async def test_publish_loop_publish_error_exception(self, mqtt_context, mocker):
+        """Test that _publish_loop logs an error when publish fails."""
+        from mqtt_handler import MqttTaskState, _publish_loop
+
+        mock_client = AsyncMock()
+
+        async def publish_side_effect(topic, *args, **kwargs):
+            if topic.endswith("/error"):
+                raise Exception("Publish error")
+
+        mock_client.publish = AsyncMock(side_effect=publish_side_effect)
+        task_state = MqttTaskState()
+
+        # Make error_msg different to trigger publish
+        mqtt_context.set_error("Connect fail", category="mqtt", trigger_event=False)
+
+        mocker.patch("mqtt_handler.logger.error")
+
+        # Trigger event once then cancel
+        call_count = 0
+
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
+
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
+
+        import mqtt_handler
+
+        mqtt_handler.logger.error.assert_called_with("MQTT Publish Failed for error: Publish error")
+
+    async def test_mqtt_task_tls_build_fail(self, mqtt_context, mocker):
+        """Test that mqtt_task retries and sleeps when TLS configuration fails."""
+        from mqtt_handler import mqtt_task
+
+        mqtt_context.config = make_test_config(tls=True)
+        mocker.patch("mqtt_handler._build_ssl_context", return_value=None)
+        mocker.patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()])
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+    async def test_mqtt_task_connection_success(self, mqtt_context, mocker):
+        """Test that mqtt_task connects, runs recovery, and sets up TaskGroup listeners successfully on happy path."""
+        from mqtt_handler import mqtt_task
+
+        mock_client = AsyncMock()
+        # Mock the context manager
+        mock_client_cm = MagicMock()
+        mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+        mocker.patch("mqtt_handler.aiomqtt.Client", return_value=mock_client_cm)
+
+        # Mock StateRecoverer
+        mock_recoverer = MagicMock()
+        mock_recoverer.run = AsyncMock()
+        mocker.patch("mqtt_handler.StateRecoverer", return_value=mock_recoverer)
+
+        # Mock TaskGroup to instantly raise CancelledError to break out after starting tasks
+        class MockTaskGroup:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                raise asyncio.CancelledError()
+
+            def create_task(self, coro):
+                pass
+
+        mocker.patch("asyncio.TaskGroup", return_value=MockTaskGroup())
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+        # Verify recovery ran, status published, subscriptions made
+        mock_recoverer.run.assert_called_once()
+        mock_client.publish.assert_any_call("s0pcmreader/status", "online", retain=True)
+        mock_client.subscribe.assert_any_call("s0pcmreader/+/total/set")
+        mock_client.subscribe.assert_any_call("s0pcmreader/+/name/set")
+        assert mqtt_context.recovery_event.is_set()
+
+    async def test_mqtt_task_connection_fail(self, mqtt_context, mocker):
+        """Test that mqtt_task sets error state and retries on broker connection failure."""
+        from mqtt_handler import mqtt_task
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__aenter__ = AsyncMock(side_effect=Exception("Connection Failed"))
+        mocker.patch("mqtt_handler.aiomqtt.Client", return_value=mock_client_cm)
+
+        mocker.patch("asyncio.sleep", side_effect=asyncio.CancelledError)
+
+        # CancelledError is caught internally and logs cancellation
+        await mqtt_task(mqtt_context)
+
+        assert "MQTT connection failed" in mqtt_context.lasterror_mqtt
+
+    async def test_mqtt_task_fatal_exception_outer(self, mocker):
+        """Test outer Exception handler in mqtt_task."""
+        from mqtt_handler import mqtt_task
+
+        context = state_module.get_context()
+        context.config = None  # This will trigger AttributeError when accessing context.config.mqtt.tls
+
+        mocker.patch("mqtt_handler.logger.error")
+
+        await mqtt_task(context)
+
+        import mqtt_handler
+
+        mqtt_handler.logger.error.assert_called_with("Fatal MQTT exception", exc_info=True)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_mqtt_handler.py
+++ b/tests/test_mqtt_handler.py
@@ -3,16 +3,16 @@ Comprehensive tests for MQTT handler functionality.
 
 Tests cover:
 - TLS setup and configuration
-- Connection error handling and retries
-- Disconnect scenarios
-- Publishing loop edge cases
+- Publishing logic
 - Error state management
 - Message handling (Set/Name topics)
 - Discovery logic integration
 """
 
+import asyncio
+import contextlib
 import ssl
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from helpers import make_test_config
 import pytest
@@ -21,329 +21,205 @@ import state as state_module
 
 
 @pytest.fixture
-def mqtt_task():
-    """Create a TaskDoMQTT instance for testing."""
-    from mqtt_handler import TaskDoMQTT
-
-    trigger = MagicMock()
-    stopper = MagicMock()
-    stopper.is_set.return_value = False
-
+def mqtt_context():
+    """Create a test context for MQTT tests."""
     context = state_module.get_context()
     context.config = make_test_config()
     context.s0pcm_reader_version = "3.0.0"
     context.s0pcm_firmware = "V0.7"
     context.lasterror_share = None
     context.state.reset_state()
-
-    return TaskDoMQTT(context, trigger, stopper)
+    return context
 
 
 class TestTLSSetup:
     """Test TLS/SSL configuration."""
 
-    def test_setup_mqtt_client_with_tls_no_ca(self, mqtt_task, mocker):
+    def test_build_ssl_context_no_ca(self, mqtt_context, mocker):
         """Test TLS setup without CA certificate (creates default context)."""
-        mqtt_task.app_context.config = make_test_config(tls=True, tls_ca="")
+        from mqtt_handler import _build_ssl_context
 
+        mqtt_context.config = make_test_config(tls=True, tls_ca="")
         mock_ssl_context = MagicMock()
         mocker.patch("ssl.SSLContext", return_value=mock_ssl_context)
 
-        result = mqtt_task._setup_mqtt_client(use_tls=True)
+        result = _build_ssl_context(mqtt_context)
 
-        assert result is True
-        # Should default to unchecked if no CA provided/verification disabled
+        assert result is not None
         assert mock_ssl_context.check_hostname is False
         assert mock_ssl_context.verify_mode == mocker.ANY
 
-    def test_setup_mqtt_client_with_tls_and_ca(self, mqtt_task, mocker):
+    def test_build_ssl_context_with_ca(self, mqtt_context, mocker):
         """Test TLS setup with CA certificate."""
-        mqtt_task.app_context.config = make_test_config(tls=True, tls_ca="/path/to/ca.crt", tls_check_peer=True)
+        from mqtt_handler import _build_ssl_context
 
+        mqtt_context.config = make_test_config(tls=True, tls_ca="/path/to/ca.crt", tls_check_peer=True)
         mock_ssl_context = MagicMock()
         mocker.patch("ssl.SSLContext", return_value=mock_ssl_context)
 
-        result = mqtt_task._setup_mqtt_client(use_tls=True)
+        result = _build_ssl_context(mqtt_context)
 
-        assert result is True
+        assert result is not None
         mock_ssl_context.load_verify_locations.assert_called_once_with(cafile="/path/to/ca.crt")
         assert mock_ssl_context.check_hostname is True
         assert mock_ssl_context.verify_mode == ssl.CERT_REQUIRED
 
-    def test_setup_mqtt_client_tls_ca_load_error(self, mqtt_task, mocker):
+    def test_build_ssl_context_ca_load_error(self, mqtt_context, mocker):
         """Test TLS setup handles CA load errors."""
-        mqtt_task.app_context.config = make_test_config(tls=True, tls_ca="/invalid/path/ca.crt")
+        from mqtt_handler import _build_ssl_context
 
+        mqtt_context.config = make_test_config(tls=True, tls_ca="/invalid/path/ca.crt")
         mock_ssl_context = MagicMock()
         mock_ssl_context.load_verify_locations.side_effect = Exception("File not found")
         mocker.patch("ssl.SSLContext", return_value=mock_ssl_context)
 
-        result = mqtt_task._setup_mqtt_client(use_tls=True)
+        result = _build_ssl_context(mqtt_context)
 
-        assert result is False
-        assert "Failed to load TLS CA file" in mqtt_task.app_context.lasterror_share
-
-    def test_setup_mqtt_client_with_username(self, mqtt_task):
-        """Test MQTT client setup with username/password."""
-        mqtt_task._setup_mqtt_client(use_tls=False)
-
-        # Verify username_pw_set was called (client is created internally)
-        assert mqtt_task._state.mqttc is not None
-
-
-class TestConnectionHandling:
-    """Test MQTT connection, disconnection, and loops."""
-
-    def test_on_connect_success(self, mqtt_task):
-        """Test successful connection callback."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task._state.mqttc = MagicMock()
-        # mqtt_task._trigger is already a MagicMock from fixture
-
-        mqtt_task.on_connect(mqtt_task._state.mqttc, None, None, 0, None)
-
-        assert mqtt_task._state.connected is True
-        assert mqtt_task._trigger.is_set()
-
-    def test_on_connect_failure(self, mqtt_task, mocker):
-        """Test connection failure callback."""
-        mqtt_task._state.mqttc = MagicMock()
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
-
-        mqtt_task.on_connect(mqtt_task._state.mqttc, None, None, 5, None)  # 5 = auth error
-
-        assert mqtt_task._state.connected is False
-        assert mock_set_error.called
-        assert "connection refused" in str(mock_set_error.call_args).lower()
-
-    def test_on_disconnect_unexpected(self, mqtt_task, mocker):
-        """Test unexpected disconnection."""
-        mqtt_task._state.mqttc = MagicMock()
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
-        mqtt_task._state.connected = True
-
-        mqtt_task.on_disconnect(mqtt_task._state.mqttc, None, None, 1, None)  # Non-zero = unexpected
-
-        assert mqtt_task._state.connected is False
-        assert mock_set_error.called
-
-    def test_on_disconnect_clean(self, mqtt_task):
-        """Test clean disconnection."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task.on_disconnect(mqtt_task._state.mqttc, None, None, 0, None)
-        assert mqtt_task._state.connected is False
-
-    @patch("time.sleep")
-    @patch("mqtt_handler.StateRecoverer")
-    def test_connect_loop_success_runs_recovery(self, mock_recoverer_cls, mock_sleep, mqtt_task, mocker):
-        """Test that successful connection triggers state recovery (lines 261-262, 65-70)."""
-        mqtt_task._stopper.is_set.side_effect = [False, True]
-
-        with patch.object(mqtt_task, "_setup_mqtt_client", return_value=True):
-            mock_client = MagicMock()
-            mqtt_task._state.mqttc = mock_client
-
-            # Simulate connected flag being set during the loop
-            def simulate_connection(*args):
-                mqtt_task._state.connected = True
-
-            mock_client.connect.side_effect = simulate_connection
-
-            mqtt_task._connect_loop()
-
-            assert mock_recoverer_cls.called
-            assert mqtt_task._state.recovery_complete is True
-
-    @patch("time.sleep")
-    def test_connect_loop_setup_failure(self, mock_sleep, mqtt_task):
-        """Test _connect_loop when _setup_mqtt_client fails (retries)."""
-        # Run loop once
-        mqtt_task._stopper.is_set.side_effect = [False, True]
-
-        with patch.object(mqtt_task, "_setup_mqtt_client", return_value=False):
-            mqtt_task._connect_loop()
-            assert mock_sleep.called
-
-    @patch("time.sleep")
-    def test_connect_loop_tls_no_fallback(self, mock_sleep, mqtt_task):
-        """Test connection loop does NOT fall back from TLS to plain on failure."""
-        context = state_module.get_context()
-        context.config = make_test_config(tls=True)
-
-        # Loop twice: both with TLS, then stop
-        mqtt_task._stopper.is_set.side_effect = [False, False, True]
-
-        mock_client = MagicMock()
-
-        with patch("mqtt_handler.mqtt.Client", return_value=mock_client):
-            mock_client.connect.side_effect = Exception("TLS Error")
-
-            mqtt_task._connect_loop()
-
-            assert "MQTT connection failed: TLS Error" in context.lasterror_share
-            assert "Falling back" not in (context.lasterror_share or "")
-            assert mock_sleep.called
+        assert result is None
+        assert "Failed to load TLS CA file" in mqtt_context.lasterror_share
 
 
 class TestMessageHandling:
     """Test MQTT message handling."""
 
-    def test_handle_set_command_by_id(self, mqtt_task):
+    async def test_handle_set_command_by_id(self, mqtt_context):
         """Test handling set command using meter ID."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(total=1000)
-        # mqtt_task._trigger is already a MagicMock from fixture
+        from mqtt_handler import _handle_set_command
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/total/set"
-        msg.payload = b"2000"
+        mqtt_context.state.meters[1] = state_module.MeterState(total=1000)
 
-        mqtt_task._handle_set_command(msg)
+        await _handle_set_command(mqtt_context, "s0pcmreader/1/total/set", b"2000")
 
-        assert mqtt_task.app_context.state.meters[1].total == 2000
-        assert mqtt_task._trigger.is_set()
+        assert mqtt_context.state.meters[1].total == 2000
+        assert mqtt_context.trigger_event.is_set()
 
-    def test_handle_set_command_by_name(self, mqtt_task):
+    async def test_handle_set_command_by_name(self, mqtt_context):
         """Test handling set command using meter name."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(name="Water", total=1000)
-        # mqtt_task._trigger is already a MagicMock from fixture
+        from mqtt_handler import _handle_set_command
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/Water/total/set"
-        msg.payload = b"2000"
+        mqtt_context.state.meters[1] = state_module.MeterState(name="Water", total=1000)
 
-        mqtt_task._handle_set_command(msg)
+        await _handle_set_command(mqtt_context, "s0pcmreader/Water/total/set", b"2000")
 
-        assert mqtt_task.app_context.state.meters[1].total == 2000
+        assert mqtt_context.state.meters[1].total == 2000
 
-    def test_handle_set_command_create_meter(self, mqtt_task):
+    async def test_handle_set_command_create_meter(self, mqtt_context):
         """Test _handle_set_command creating a meter if it doesn't exist."""
-        context = state_module.get_context()
-        context.state.meters = {}
+        from mqtt_handler import _handle_set_command
 
-        msg = MagicMock()
-        msg.topic = "s0pcm/5/total/set"
-        msg.payload = b"1000"
+        mqtt_context.state.meters = {}
 
-        mqtt_task._handle_set_command(msg)
+        await _handle_set_command(mqtt_context, "s0pcmreader/5/total/set", b"1000")
 
-        assert 5 in context.state.meters
-        assert context.state.meters[5].total == 1000
+        assert 5 in mqtt_context.state.meters
+        assert mqtt_context.state.meters[5].total == 1000
 
-    def test_handle_set_command_invalid_payload(self, mqtt_task, mocker):
+    async def test_handle_set_command_invalid_payload(self, mqtt_context, mocker):
         """Test handling set command with invalid payload."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(total=1000)
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
+        from mqtt_handler import _handle_set_command
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/total/set"
-        msg.payload = b"not_a_number"
+        mqtt_context.state.meters[1] = state_module.MeterState(total=1000)
+        mock_set_error = mocker.patch.object(mqtt_context, "set_error")
 
-        mqtt_task._handle_set_command(msg)
+        await _handle_set_command(mqtt_context, "s0pcmreader/1/total/set", b"not_a_number")
 
         assert mock_set_error.called
         assert "invalid payload" in str(mock_set_error.call_args).lower()
 
-    def test_handle_set_command_exception(self, mqtt_task):
+    async def test_handle_set_command_exception(self, mqtt_context):
         """Test exception handling in _handle_set_command."""
-        context = state_module.get_context()
-        msg = MagicMock()
-        msg.topic = None  # Causes Exception on split
-        mqtt_task._handle_set_command(msg)
-        assert "Failed to process MQTT set command" in context.lasterror_share
+        from mqtt_handler import _handle_set_command
 
-    def test_handle_name_set(self, mqtt_task, mocker):
+        # None topic causes Exception on split
+        with contextlib.suppress(Exception):
+            await _handle_set_command(mqtt_context, None, b"1000")
+        # With proper exception handling it should set error
+        assert mqtt_context.lasterror_share is not None or mqtt_context.lasterror_mqtt is not None
+
+    async def test_handle_name_set(self, mqtt_context, mocker):
         """Test handling name set command."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState()
-        mqtt_task._state.mqttc = MagicMock()
-        # Trigger is already MagicMock from fixture
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-        mocker.patch("mqtt_handler.discovery.send_global_discovery")
-        mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="NewName")
+        mqtt_context.state.meters[1] = state_module.MeterState()
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/name/set"
-        msg.payload = b"NewName"
+        mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="NewName")
 
-        mqtt_task._handle_name_set(msg)
+        await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"NewName")
 
-        assert mqtt_task.app_context.state.meters[1].name == "NewName"
-        assert mqtt_task._trigger.is_set()
+        assert mqtt_context.state.meters[1].name == "NewName"
+        assert mqtt_context.trigger_event.is_set()
 
-    def test_handle_name_set_empty(self, mqtt_task, mocker):
+    async def test_handle_name_set_empty(self, mqtt_context, mocker):
         """Test handling name set with empty payload (clear name)."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(name="OldName")
-        mqtt_task._state.mqttc = MagicMock()
-        # Trigger is already MagicMock from fixture
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-        mocker.patch("mqtt_handler.discovery.send_global_discovery")
-        mocker.patch("mqtt_handler.discovery.send_meter_discovery")
+        mqtt_context.state.meters[1] = state_module.MeterState(name="OldName")
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/name/set"
-        msg.payload = b""
+        mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock)
 
-        mqtt_task._handle_name_set(msg)
+        await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"")
 
-        assert mqtt_task.app_context.state.meters[1].name is None
+        assert mqtt_context.state.meters[1].name is None
 
-    def test_handle_name_set_exception(self, mqtt_task):
+    async def test_handle_name_set_exception(self, mqtt_context):
         """Test exception handling in _handle_name_set."""
-        context = state_module.get_context()
-        msg = MagicMock()
-        msg.topic = None
-        mqtt_task._handle_name_set(msg)
-        assert "Failed to process MQTT name/set command" in context.lasterror_share
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-    def test_on_message_dispatch(self, mqtt_task):
-        """Test on_message dispatching to handlers."""
-        mqtt_task._handle_set_command = MagicMock()
-        mqtt_task._handle_name_set = MagicMock()
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
-        msg_set = MagicMock()
-        msg_set.topic = "s0pcm/1/total/set"
-        mqtt_task.on_message(None, None, msg_set)
-        mqtt_task._handle_set_command.assert_called_once_with(msg_set)
-
-        msg_name = MagicMock()
-        msg_name.topic = "s0pcm/1/name/set"
-        mqtt_task.on_message(None, None, msg_name)
-        mqtt_task._handle_name_set.assert_called_once_with(msg_name)
+        await _handle_name_set(mqtt_context, mock_client, task_state, None, b"Name")
+        assert mqtt_context.lasterror_mqtt is not None
+        assert "Failed to process MQTT name/set command" in mqtt_context.lasterror_mqtt
 
 
 class TestPublishingLogic:
     """Test MQTT publishing logic."""
 
-    def test_publish_diagnostics_change_detection(self, mqtt_task):
+    async def test_publish_diagnostics_change_detection(self, mqtt_context):
         """Test diagnostics only publish on change."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task.app_context.s0pcm_reader_version = "3.0.0"
-        mqtt_task.app_context.s0pcm_firmware = "V0.7"
+        from mqtt_handler import MqttTaskState, _publish_diagnostics
+
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
         # First publish
-        mqtt_task._publish_diagnostics()
-        first_call_count = mqtt_task._state.mqttc.publish.call_count
+        await _publish_diagnostics(mqtt_context, mock_client, task_state)
+        assert mock_client.publish.call_count > 0
 
         # Second publish with same values
-        mqtt_task._publish_diagnostics()
-        second_call_count = mqtt_task._state.mqttc.publish.call_count
+        mock_client.publish.reset_mock()
+        await _publish_diagnostics(mqtt_context, mock_client, task_state)
 
         # Should not publish again if values haven't changed
-        assert second_call_count == first_call_count
+        assert mock_client.publish.call_count == 0
 
-    def test_publish_diagnostics_exception(self, mqtt_task):
+    async def test_publish_diagnostics_exception(self, mqtt_context):
         """Test exception handling in _publish_diagnostics."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task._state.mqttc.publish.side_effect = Exception("Publish error")
+        from mqtt_handler import MqttTaskState, _publish_diagnostics
+
+        mock_client = AsyncMock()
+        mock_client.publish = AsyncMock(side_effect=Exception("Publish error"))
+        task_state = MqttTaskState()
+
         with patch("mqtt_handler.logger.error") as mock_logger:
-            mqtt_task._publish_diagnostics()
+            await _publish_diagnostics(mqtt_context, mock_client, task_state)
             assert mock_logger.called
             assert "Failed to publish info state" in mock_logger.call_args[0][0]
 
-    def test_publish_measurements_date_change(self, mqtt_task):
+    async def test_publish_measurements_date_change(self, mqtt_context):
         """Test publishing date when it changes."""
-        mqtt_task._state.mqttc = MagicMock()
-
         import datetime
+
+        from mqtt_handler import _publish_measurements
+
+        mock_client = AsyncMock()
 
         state_snapshot = state_module.AppState()
         state_snapshot.date = datetime.date(2026, 1, 25)
@@ -351,28 +227,30 @@ class TestPublishingLogic:
         previous_snapshot = state_module.AppState()
         previous_snapshot.date = datetime.date(2026, 1, 24)
 
-        mqtt_task._publish_measurements(state_snapshot, previous_snapshot)
+        await _publish_measurements(mqtt_context, mock_client, state_snapshot, previous_snapshot)
 
         # Verify date was published
-        date_calls = [c for c in mqtt_task._state.mqttc.publish.call_args_list if "/date" in str(c)]
+        date_calls = [c for c in mock_client.publish.call_args_list if "/date" in str(c)]
         assert len(date_calls) > 0
 
-    def test_publish_measurements_split_topic_mode(self, mqtt_task):
+    async def test_publish_measurements_split_topic_mode(self, mqtt_context):
         """Test publishing in split_topic mode."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task.app_context.config = make_test_config(split_topic=True)
+        from mqtt_handler import _publish_measurements
+
+        mock_client = AsyncMock()
+        mqtt_context.config = make_test_config(split_topic=True)
 
         state_snapshot = state_module.AppState()
         state_snapshot.meters[1] = state_module.MeterState(name="Water", total=1000, today=50)
 
-        mqtt_task._publish_measurements(state_snapshot, None)
+        await _publish_measurements(mqtt_context, mock_client, state_snapshot, None)
 
         # Verify split topics were published
-        assert mqtt_task._state.mqttc.publish.called
-        assert mqtt_task._state.mqttc.publish.call_count >= 3  # total, today, pulsecount
+        assert mock_client.publish.called
+        assert mock_client.publish.call_count >= 3  # total, today, pulsecount
 
         # Regression check: Ensure topics do NOT contain function/object string representations
-        published_topics = [str(call.args[0]) for call in mqtt_task._state.mqttc.publish.call_args_list]
+        published_topics = [str(call.args[0]) for call in mock_client.publish.call_args_list]
         for topic in published_topics:
             assert "<function" not in topic
             assert "field at" not in topic
@@ -382,436 +260,254 @@ class TestPublishingLogic:
         assert any(t.endswith("/total") for t in published_topics)
         assert any(t.endswith("/today") for t in published_topics)
 
-    def test_publish_measurements_disabled_meter(self, mqtt_task):
+    async def test_publish_measurements_disabled_meter(self, mqtt_context):
         """Test _publish_measurements skip disabled meter."""
-        mqtt_task._state.mqttc = MagicMock()
+        from mqtt_handler import _publish_measurements
+
+        mock_client = AsyncMock()
         state_snapshot = state_module.AppState()
         state_snapshot.meters[1] = state_module.MeterState(enabled=True, total=100)
         state_snapshot.meters[2] = state_module.MeterState(enabled=False, total=200)
 
-        mqtt_task._publish_measurements(state_snapshot, None)
+        await _publish_measurements(mqtt_context, mock_client, state_snapshot, None)
 
-        published_topics = [str(call.args[0]) for call in mqtt_task._state.mqttc.publish.call_args_list]
-        assert any("/1/" in topic or "Water" in topic for topic in published_topics)  # Check for ID or Name
+        published_topics = [str(call.args[0]) for call in mock_client.publish.call_args_list]
+        assert any("/1/" in topic or "Water" in topic for topic in published_topics)
         assert not any("/2/" in topic for topic in published_topics)
 
+    async def test_publish_measurements_combined_topic_mode(self, mqtt_context):
+        """Test publishing when split_topic is False (JSON mode)."""
+        from mqtt_handler import _publish_measurements
 
-class TestMainLoop:
-    """Test the main MQTT loop."""
+        mock_client = AsyncMock()
+        mqtt_context.config = make_test_config(split_topic=False)
 
-    def test_main_loop_discovery_sent_once(self, mqtt_task, mocker):
-        """Test that discovery is only sent once."""
-        mqtt_task._state.connected = True
-        mqtt_task._state.mqttc = MagicMock()
-        # Trigger and stopper are already MagicMocks from fixture
+        state_snapshot = state_module.AppState()
+        state_snapshot.meters[1] = state_module.MeterState(name="Water", total=1000, today=50)
 
-        mock_send_global = mocker.patch("mqtt_handler.discovery.send_global_discovery")
-        mock_cleanup = mocker.patch("mqtt_handler.discovery.cleanup_meter_discovery")
+        await _publish_measurements(mqtt_context, mock_client, state_snapshot, None)
 
-        # Trigger one iteration then stop
-        def stop_after_first(*args):
-            mqtt_task._stopper.is_set.return_value = True
-
-        mqtt_task._trigger.wait.side_effect = stop_after_first
-
-        mqtt_task._main_loop()
-
-        # Discovery should be sent exactly once
-        assert mock_send_global.call_count == 1
-        # Cleanup should be called for meters 1-5
-        assert mock_cleanup.call_count == 5
-
-    def test_main_loop_exits_on_disconnect(self, mqtt_task):
-        """Test main loop exits when disconnected."""
-        mqtt_task._state.connected = False
-        mqtt_task._state.mqttc = MagicMock()
-
-        mqtt_task._main_loop()
-
-        # Should return immediately without publishing
-        assert mqtt_task._state.mqttc.publish.call_count == 0
-
-    def test_main_loop_error_publish_exception(self, mqtt_task):
-        """Test exception handling in _main_loop when publishing errors."""
-        mqtt_task._state.connected = True
-        mqtt_task._state.mqttc = MagicMock()
-        # Stopper and trigger are already MagicMocks from fixture
-
-        def mock_publish(topic, *args, **kwargs):
-            if "/error" in topic:
-                raise Exception("Error topic failure")
-            return MagicMock()
-
-        mqtt_task._state.mqttc.publish.side_effect = mock_publish
-        mqtt_task._state.global_discovery_sent = True
-
-        # Make loop run once
-        mqtt_task._stopper.is_set.side_effect = [False, True]
-
-        # Set an error to force publish call
-        mqtt_task.app_context.lasterror_share = "Some Error"
-
-        with patch("mqtt_handler.logger.error") as mock_logger:
-            mqtt_task._main_loop()
-            assert mock_logger.called
-            assert "MQTT Publish Failed" in mock_logger.call_args[0][0]
-
-    def test_main_loop_error_publish_success_with_timer(self, mqtt_task, mocker):
-        """Test successful error publish in _main_loop triggers the delayed clear timer."""
-        mqtt_task._state.connected = True
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task._state.global_discovery_sent = True
-
-        # Mock threading.Timer to verify it gets called
-        mock_timer = mocker.patch("mqtt_handler.threading.Timer")
-
-        # We need the timer instance's start method to be a mock so we can verify it
-        mock_timer_instance = MagicMock()
-        mock_timer.return_value = mock_timer_instance
-
-        # Make loop run once
-        mqtt_task._stopper.is_set.side_effect = [False, True]
-
-        # Set an error to force publish call
-        mqtt_task.app_context.lasterror_share = "Connection Refused"
-
-        mqtt_task._main_loop()
-
-        # Verify mqtt publish was called for the error topic
-        publish_calls = [
-            call for call in mqtt_task._state.mqttc.publish.call_args_list if "/error" in str(call.args[0])
-        ]
-        assert len(publish_calls) > 0
-        assert "Connection Refused" in publish_calls[0].args[1]
-
-        # Verify threading.Timer was instantiated with 15.0 seconds and a callable
-        assert mock_timer.called
-        assert mock_timer.call_args[0][0] == 15.0
-        assert callable(mock_timer.call_args[0][1])
-
-        # Verify the timer was actually started
-        assert mock_timer_instance.start.called
-
-        # Test the delayed_clear callback directly
-        delayed_clear_func = mock_timer.call_args[0][1]
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
-
-        # 1. Test when still connected
-        mqtt_task._state.connected = True
-        delayed_clear_func()
-        mock_set_error.assert_called_once_with(None, category="mqtt")
-
-        # 2. Test when disconnected (should not clear)
-        mock_set_error.reset_mock()
-        mqtt_task._state.connected = False
-        delayed_clear_func()
-        assert not mock_set_error.called
-
-    def test_run_fatal_exception(self, mqtt_task, mocker):
-        """Test fatal exception handling in run()."""
-        mocker.patch.object(mqtt_task, "_connect_loop", side_effect=Exception("Fatal Run Error"))
-        mqtt_task._stopper.is_set.return_value = False
-
-        with patch("mqtt_handler.logger.error") as mock_logger:
-            mqtt_task.run()
-            assert mock_logger.called
-            assert "Fatal MQTT exception" in mock_logger.call_args[0][0]
-            assert mqtt_task._stopper.set.called
+        # Verify JSON was published
+        json_calls = [c for c in mock_client.publish.call_args_list if '"total": 1000' in str(c.args[1])]
+        assert len(json_calls) > 0
+        payload = json_calls[0].args[1]
+        assert '"today": 50' in payload
 
 
-def test_handle_name_set_triggers_discovery(mqtt_task, mocker):
-    """Test that setting a name triggers discovery for all meters (lines 169-172)."""
-    # Setup context with meters
-    context = state_module.get_context()
-    context.state.meters[1] = state_module.MeterState(total=100)
-    context.state.meters[2] = state_module.MeterState(total=200)
-    context.config = make_test_config(discovery=True)
+async def test_handle_name_set_triggers_discovery(mqtt_context, mocker):
+    """Test that setting a name triggers discovery for all meters."""
+    from mqtt_handler import MqttTaskState, _handle_name_set
 
-    # Mock both discovery functions
-    mocker.patch("mqtt_handler.discovery.send_global_discovery")
-    mock_send = mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="TestMeter")
+    mqtt_context.state.meters[1] = state_module.MeterState(total=100)
+    mqtt_context.state.meters[2] = state_module.MeterState(total=200)
+    mqtt_context.config = make_test_config(discovery=True)
 
-    # Trigger name set
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/1/name/set"
-    msg.payload = b"NewName"
+    mock_client = AsyncMock()
+    task_state = MqttTaskState()
 
-    mqtt_task._handle_name_set(msg)
+    mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+    mock_send = mocker.patch(
+        "mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="TestMeter"
+    )
+
+    await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"NewName")
 
     # Should have sent discovery for all meters
     assert mock_send.call_count == 2
-    assert mqtt_task._state.global_discovery_sent is True
-    assert mqtt_task._trigger.set.called
+    assert task_state.global_discovery_sent is True
+    assert mqtt_context.trigger_event.is_set()
 
 
-def test_handle_name_set_exception_handling(mqtt_task, mocker):
-    """Test exception handling in _handle_name_set (lines 172-173)."""
-    context = state_module.get_context()
-    context.config = make_test_config(discovery=True)
+async def test_handle_name_set_exception_handling(mqtt_context, mocker):
+    """Test exception handling in _handle_name_set."""
+    from mqtt_handler import MqttTaskState, _handle_name_set
+
+    mqtt_context.config = make_test_config(discovery=True)
+    mock_client = AsyncMock()
+    task_state = MqttTaskState()
 
     # Mock send_meter_discovery to raise an exception
-    mocker.patch("mqtt_handler.discovery.send_meter_discovery", side_effect=Exception("Test error"))
+    mocker.patch(
+        "mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, side_effect=Exception("Test error")
+    )
 
     # Add a meter
-    context.state.meters[1] = state_module.MeterState(total=100)
+    mqtt_context.state.meters[1] = state_module.MeterState(total=100)
 
-    # Trigger name set
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/1/name/set"
-    msg.payload = b"NewName"
-
-    # Should not crash, should set error
-    mqtt_task._handle_name_set(msg)
-    assert context.lasterror_mqtt is not None
+    await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"NewName")
+    assert mqtt_context.lasterror_mqtt is not None
 
 
-def test_handle_total_set_unknown_meter(mqtt_task):
-    """Test total/set command for unknown meter name (lines 108-109)."""
-    context = state_module.get_context()
-    context.state.meters[1] = state_module.MeterState(name="Water")
+async def test_handle_total_set_unknown_meter(mqtt_context):
+    """Test total/set command for unknown meter name."""
+    from mqtt_handler import _handle_set_command
 
-    # Trigger set for non-existent meter by name
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/UnknownMeter/total/set"
-    msg.payload = b"1000"
+    mqtt_context.state.meters[1] = state_module.MeterState(name="Water")
 
-    mqtt_task._handle_set_command(msg)
+    await _handle_set_command(mqtt_context, "s0pcmreader/UnknownMeter/total/set", b"1000")
 
-    # Should set error for unknown meter
-    assert context.lasterror_mqtt is not None
-    assert "unknown meter" in context.lasterror_mqtt.lower()
+    assert mqtt_context.lasterror_mqtt is not None
+    assert "unknown meter" in mqtt_context.lasterror_mqtt.lower()
 
 
-def test_handle_name_set_unknown_meter_by_name(mqtt_task):
-    """Test name/set command for unknown meter name (lines 141-149)."""
-    context = state_module.get_context()
-    context.state.meters[1] = state_module.MeterState(name="Water")
+async def test_handle_name_set_unknown_meter_by_name(mqtt_context):
+    """Test name/set command for unknown meter name."""
+    from mqtt_handler import MqttTaskState, _handle_name_set
 
-    # Trigger name set for non-existent meter name
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/NonExistent/name/set"
-    msg.payload = b"NewName"
+    mqtt_context.state.meters[1] = state_module.MeterState(name="Water")
+    mock_client = AsyncMock()
+    task_state = MqttTaskState()
 
-    mqtt_task._handle_name_set(msg)
+    await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/NonExistent/name/set", b"NewName")
 
-    # Should set error for unknown meter
-    assert context.lasterror_mqtt is not None
-    assert "unknown meter" in context.lasterror_mqtt.lower()
+    assert mqtt_context.lasterror_mqtt is not None
+    assert "unknown meter" in mqtt_context.lasterror_mqtt.lower()
 
 
-def test_handle_name_set_by_name_lookup(mqtt_task, mocker):
-    """Test name/set with name-based meter lookup (lines 144-145)."""
-    context = state_module.get_context()
-    context.state.meters[5] = state_module.MeterState(name="WaterMeter")
-    context.config = make_test_config(discovery=True)
+async def test_handle_name_set_by_name_lookup(mqtt_context, mocker):
+    """Test name/set with name-based meter lookup."""
+    from mqtt_handler import MqttTaskState, _handle_name_set
 
-    mocker.patch("mqtt_handler.discovery.send_global_discovery")
-    mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="Water")
+    mqtt_context.state.meters[5] = state_module.MeterState(name="WaterMeter")
+    mqtt_context.config = make_test_config(discovery=True)
+    mock_client = AsyncMock()
+    task_state = MqttTaskState()
 
-    # Use meter name instead of ID
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/WaterMeter/name/set"
-    msg.payload = b"NewWaterName"
+    mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+    mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="Water")
 
-    mqtt_task._handle_name_set(msg)
+    await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/WaterMeter/name/set", b"NewWaterName")
 
-    # Should find meter by name and update it
-    assert context.state.meters[5].name == "NewWaterName"
+    assert mqtt_context.state.meters[5].name == "NewWaterName"
 
 
-def test_handle_name_set_creates_new_meter(mqtt_task, mocker):
-    """Test name/set creates new meter if ID doesn't exist (line 159)."""
-    context = state_module.get_context()
-    context.config = make_test_config(discovery=True)
+async def test_handle_name_set_creates_new_meter(mqtt_context, mocker):
+    """Test name/set creates new meter if ID doesn't exist."""
+    from mqtt_handler import MqttTaskState, _handle_name_set
 
-    mocker.patch("mqtt_handler.discovery.send_global_discovery")
-    mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="Test")
+    mqtt_context.config = make_test_config(discovery=True)
+    mock_client = AsyncMock()
+    task_state = MqttTaskState()
 
-    # Set name for non-existent meter ID
-    msg = MagicMock()
-    msg.topic = "s0pcmreader/7/name/set"
-    msg.payload = b"NewMeter"
+    mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+    mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="Test")
 
-    mqtt_task._handle_name_set(msg)
+    await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/7/name/set", b"NewMeter")
 
-    # Should create new meter
-    assert 7 in context.state.meters
-    assert context.state.meters[7].name == "NewMeter"
+    assert 7 in mqtt_context.state.meters
+    assert mqtt_context.state.meters[7].name == "NewMeter"
 
 
 class TestSecurityHardening:
     """Tests for security hardening measures."""
 
-    def test_name_set_sanitizes_mqtt_characters(self, mqtt_task, mocker):
+    async def test_name_set_sanitizes_mqtt_characters(self, mqtt_context, mocker):
         """Test that /+# characters are stripped from meter names."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState()
-        mqtt_task._state.mqttc = MagicMock()
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-        mocker.patch("mqtt_handler.discovery.send_global_discovery")
-        mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="MyMeter")
+        mqtt_context.state.meters[1] = state_module.MeterState()
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/name/set"
-        msg.payload = b"My/Meter+Name#Test"
+        mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="MyMeter")
 
-        mqtt_task._handle_name_set(msg)
+        await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"My/Meter+Name#Test")
 
-        assert mqtt_task.app_context.state.meters[1].name == "MyMeterNameTest"
+        assert mqtt_context.state.meters[1].name == "MyMeterNameTest"
 
-    def test_name_set_only_special_chars_becomes_none(self, mqtt_task, mocker):
+    async def test_name_set_only_special_chars_becomes_none(self, mqtt_context, mocker):
         """Test that a name consisting only of MQTT special chars becomes None."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(name="OldName")
-        mqtt_task._state.mqttc = MagicMock()
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-        mocker.patch("mqtt_handler.discovery.send_global_discovery")
-        mocker.patch("mqtt_handler.discovery.send_meter_discovery")
+        mqtt_context.state.meters[1] = state_module.MeterState(name="OldName")
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/name/set"
-        msg.payload = b"/+#"
+        mocker.patch("mqtt_handler.discovery.send_global_discovery", new_callable=AsyncMock)
+        mocker.patch("mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock)
 
-        mqtt_task._handle_name_set(msg)
+        await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"/+#")
 
-        assert mqtt_task.app_context.state.meters[1].name is None
+        assert mqtt_context.state.meters[1].name is None
 
-    def test_handle_set_command_oversized_payload(self, mqtt_task, mocker):
+    async def test_handle_set_command_oversized_payload(self, mqtt_context, mocker):
         """Test that oversized payloads on total/set are rejected."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(total=1000)
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
+        from mqtt_handler import _handle_set_command
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/total/set"
-        msg.payload = b"x" * 257
+        mqtt_context.state.meters[1] = state_module.MeterState(total=1000)
+        mock_set_error = mocker.patch.object(mqtt_context, "set_error")
 
-        mqtt_task._handle_set_command(msg)
+        await _handle_set_command(mqtt_context, "s0pcmreader/1/total/set", b"x" * 257)
 
         assert mock_set_error.called
         assert "oversized payload" in str(mock_set_error.call_args).lower()
         # Total should NOT have changed
-        assert mqtt_task.app_context.state.meters[1].total == 1000
+        assert mqtt_context.state.meters[1].total == 1000
 
-    def test_handle_name_set_oversized_payload(self, mqtt_task, mocker):
+    async def test_handle_name_set_oversized_payload(self, mqtt_context, mocker):
         """Test that oversized payloads on name/set are rejected."""
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(name="Water")
-        mock_set_error = mocker.patch.object(mqtt_task.app_context, "set_error")
+        from mqtt_handler import MqttTaskState, _handle_name_set
 
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/name/set"
-        msg.payload = b"A" * 257
+        mqtt_context.state.meters[1] = state_module.MeterState(name="Water")
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+        mock_set_error = mocker.patch.object(mqtt_context, "set_error")
 
-        mqtt_task._handle_name_set(msg)
+        await _handle_name_set(mqtt_context, mock_client, task_state, "s0pcmreader/1/name/set", b"A" * 257)
 
         assert mock_set_error.called
         assert "oversized payload" in str(mock_set_error.call_args).lower()
         # Name should NOT have changed
-        assert mqtt_task.app_context.state.meters[1].name == "Water"
+        assert mqtt_context.state.meters[1].name == "Water"
 
 
 class TestMQTTAdditionalCoverage:
     """Additional tests to reach near-100% coverage."""
 
-    def test_publish_measurements_combined_topic_mode(self, mqtt_task):
-        """Test publishing when split_topic is False (JSON mode) (lines 340, 351-353)."""
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task.app_context.config = make_test_config(split_topic=False)
+    async def test_publish_loop_discovery(self, mqtt_context, mocker):
+        """Test that _publish_loop sends discovery for new meters."""
+        from mqtt_handler import MqttTaskState, _publish_loop
 
-        state_snapshot = state_module.AppState()
-        state_snapshot.meters[1] = state_module.MeterState(name="Water", total=1000, today=50)
+        mock_client = AsyncMock()
+        task_state = MqttTaskState()
+        task_state.global_discovery_sent = True  # Skip global discovery
 
-        mqtt_task._publish_measurements(state_snapshot, None)
+        # Add a meter
+        mqtt_context.state.meters[1] = state_module.MeterState(name="TestMeter")
 
-        # Verify JSON was published (look for the call where the second arg is a JSON string containing total)
-        json_calls = [c for c in mqtt_task._state.mqttc.publish.call_args_list if '"total": 1000' in str(c.args[1])]
-        assert len(json_calls) > 0
-        payload = json_calls[0].args[1]
-        assert '"today": 50' in payload
+        mock_send = mocker.patch(
+            "mqtt_handler.discovery.send_meter_discovery", new_callable=AsyncMock, return_value="TestMeter"
+        )
 
-    def test_main_loop_meter_discovery(self, mqtt_task, mocker):
-        """Test that _main_loop sends discovery for new meters (lines 375-379)."""
-        mqtt_task._state.connected = True
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task._state.global_discovery_sent = True  # Skip global discovery
+        # Make trigger event fire once then cancel
+        call_count = 0
 
-        # Add a meter that hasn't been discovered yet
-        mqtt_task.app_context.state.meters[1] = state_module.MeterState(name="TestMeter")
-        # CRITICAL: _main_loop reads from state_share
-        mqtt_task.app_context.state_share = mqtt_task.app_context.state.model_copy(deep=True)
+        async def trigger_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError()
 
-        mock_send = mocker.patch("mqtt_handler.discovery.send_meter_discovery", return_value="TestMeter")
+        mqtt_context.trigger_event.wait = trigger_once
+        mqtt_context.trigger_event.set()
 
-        # Trigger one iteration then stop
-        def stop_after_first(*args):
-            mqtt_task._stopper.is_set.return_value = True
-
-        mqtt_task._trigger.wait.side_effect = stop_after_first
-        mqtt_task._main_loop()
+        with pytest.raises(asyncio.CancelledError):
+            await _publish_loop(mqtt_context, mock_client, task_state)
 
         assert mock_send.call_count == 1
-        assert mqtt_task._state.discovered_meters[1] == "TestMeter"
+        assert task_state.discovered_meters[1] == "TestMeter"
 
-    def test_run_cleanup_logic(self, mqtt_task, mocker):
-        """Test cleanup logic in run() when main_loop returns (lines 409-419)."""
-        # Mock _connect_loop to do nothing
-        mocker.patch.object(mqtt_task, "_connect_loop")
-        # Mock _main_loop to return immediately
-        mocker.patch.object(mqtt_task, "_main_loop")
+    def test_resolve_meter_id_by_name(self, mqtt_context):
+        """Test resolving meter ID by name."""
+        from mqtt_handler import _resolve_meter_id
 
-        # Setup state
-        mock_mqttc = MagicMock()
-        mqtt_task._state.mqttc = mock_mqttc
-        mqtt_task._state.connected = True
-        mqtt_task._stopper.is_set.side_effect = [False, True]  # Run once
+        mqtt_context.state.meters[1] = state_module.MeterState(name="Water")
 
-        mqtt_task.run()
-
-        # Should have published offline status
-        assert mock_mqttc.publish.called
-        # Should have stopped loop and disconnected
-        assert mock_mqttc.loop_stop.called
-        assert mock_mqttc.disconnect.called
-        assert mqtt_task._state.mqttc is None
-
-    @patch("time.sleep")
-    @patch("time.time")
-    def test_connect_loop_timeout(self, mock_time, mock_sleep, mqtt_task, mocker):
-        """Test _connect_loop times out waiting for connection (lines 248, 254)."""
-        # Run loop once
-        mqtt_task._stopper.is_set.side_effect = [False, False, False, True, True, True]
-        mqtt_task._state.mqttc = MagicMock()
-        mqtt_task._state.connected = False
-
-        # Mock _setup_mqtt_client to prevent it from creating a real client in 2nd loop
-        mocker.patch.object(mqtt_task, "_setup_mqtt_client", return_value=True)
-
-        # Simulate time passing:
-        # 1. 100 (start time) -> timeout = 110
-        # 2. 105 (loop check 1 - True)
-        # 3. 115 (loop check 2 - False)
-        # 4. 116 (logging/error time)
-        mock_time.side_effect = [100, 105, 115, 116, 117, 118, 119, 120, 121, 122]
-
-        with patch.object(mqtt_task.app_context, "set_error") as mock_set_error:
-            mqtt_task._connect_loop()
-
-            assert mock_set_error.called
-            # Check if ANY of the calls contain the timeout message
-            all_errors = " ".join(str(call) for call in mock_set_error.call_args_list).lower()
-            assert "timeout waiting for mqtt connack" in all_errors
-
-    @patch("time.sleep")
-    def test_connect_loop_general_failure(self, mock_sleep, mqtt_task):
-        """Test _connect_loop handled general exception (lines 265-267)."""
-        # Run loop once
-        mqtt_task._stopper.is_set.side_effect = [False, True]
-
-        mock_client = MagicMock()
-        mock_client.connect.side_effect = Exception("Socket Error")
-
-        with patch("mqtt_handler.mqtt.Client", return_value=mock_client):
-            mqtt_task._connect_loop()
-
-            assert "MQTT connection failed: Socket Error" in mqtt_task.app_context.lasterror_share
-            assert mock_sleep.called
+        assert _resolve_meter_id(mqtt_context, "Water") == 1
+        assert _resolve_meter_id(mqtt_context, "water") == 1  # Case-insensitive
+        assert _resolve_meter_id(mqtt_context, "NonExistent") is None
+        assert _resolve_meter_id(mqtt_context, "1") == 1  # Numeric ID
 
 
 if __name__ == "__main__":

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -9,6 +9,7 @@ Tests cover:
 - Complete recovery flow and edge cases
 """
 
+import asyncio
 import datetime
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -329,6 +330,34 @@ class TestRecoveryFlow:
 
         # Verify unsubscriptions
         assert recoverer.client.unsubscribe.call_count == 6
+
+    async def test_run_receives_retained_messages_and_timeouts(self, recoverer, mocker):
+        """Test that run() successfully processes received messages and handles TimeoutError gracefully."""
+
+        # Yield a couple of messages, then wait to trigger TimeoutError
+        async def message_generator():
+            msg1 = MagicMock()
+            msg1.topic = "s0pcmreader/1/total"
+            msg1.payload = b"12345"
+            yield msg1
+
+            msg2 = MagicMock()
+            msg2.topic = "s0pcmreader/Water/name"
+            msg2.payload = b"Water"
+            yield msg2
+
+            await asyncio.sleep(0.05)  # sleep to let timeout happen
+
+        recoverer.client.messages = message_generator()
+
+        # Set recovery wait to a very small value so timeout is quick
+        recoverer.context.config.mqtt.recovery_wait = 0.01
+
+        await recoverer.run()
+
+        # Check that the messages were processed and saved to recovered_data
+        assert "1" in recoverer.recovered_data
+        assert recoverer.recovered_data["1"]["total"] == 12345
 
     async def test_run_initializes_meters_from_mqtt_data(self, recoverer, mocker):
         """Test that run() initializes meters from recovered MQTT data."""

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -125,7 +125,7 @@ class TestMQTTMessageParsing:
 class TestHAAPIFallback:
     """Test Home Assistant API fallback methods."""
 
-    def test_fetch_ha_state_success(self, recoverer, mocker):
+    async def test_fetch_ha_state_success(self, recoverer, mocker):
         """Test successful HA API state fetch."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -139,19 +139,19 @@ class TestHAAPIFallback:
 
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result == "1234567"
 
-    def test_fetch_ha_state_no_token(self, recoverer, mocker):
+    async def test_fetch_ha_state_no_token(self, recoverer, mocker):
         """Test HA API fetch returns None when no token available."""
         mocker.patch.dict("os.environ", {}, clear=True)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result is None
 
-    def test_fetch_ha_state_unknown_state(self, recoverer, mocker):
+    async def test_fetch_ha_state_unknown_state(self, recoverer, mocker):
         """Test HA API fetch returns None for unknown/unavailable states."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
         mock_response = MagicMock()
@@ -163,11 +163,23 @@ class TestHAAPIFallback:
         mock_response.__exit__ = lambda self, *args: None
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
 
         assert result is None
 
-    def test_fetch_all_ha_states_success(self, recoverer, mocker):
+    async def test_fetch_ha_state_status_not_200(self, recoverer, mocker):
+        """Test fetch HA state returns None when response status is not 200."""
+        mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
+        mock_response = MagicMock()
+        mock_response.status = 204
+        mock_response.__enter__ = lambda self: self
+        mock_response.__exit__ = lambda self, *args: None
+        mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+        result = await recoverer.fetch_ha_state("sensor.s0pcmreader_1_total")
+        assert result is None
+
+    async def test_fetch_all_ha_states_success(self, recoverer, mocker):
         """Test successful fetch of all HA states."""
         mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -184,18 +196,30 @@ class TestHAAPIFallback:
 
         mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-        result = recoverer.fetch_all_ha_states()
+        result = await recoverer.fetch_all_ha_states()
 
         assert len(result) == 2
         assert result[0]["entity_id"] == "sensor.s0pcmreader_1_total"
         assert result[1]["state"] == "5000"
 
-    def test_fetch_all_ha_states_no_token(self, recoverer, mocker):
+    async def test_fetch_all_ha_states_no_token(self, recoverer, mocker):
         """Test fetch all states returns empty list when no token."""
         mocker.patch.dict("os.environ", {}, clear=True)
 
-        result = recoverer.fetch_all_ha_states()
+        result = await recoverer.fetch_all_ha_states()
 
+        assert result == []
+
+    async def test_fetch_all_ha_states_status_not_200(self, recoverer, mocker):
+        """Test fetch all states returns empty list when response status is not 200."""
+        mocker.patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test_token"})
+        mock_response = MagicMock()
+        mock_response.status = 204
+        mock_response.__enter__ = lambda self: self
+        mock_response.__exit__ = lambda self, *args: None
+        mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+        result = await recoverer.fetch_all_ha_states()
         assert result == []
 
 
@@ -410,6 +434,7 @@ class TestRecoveryFlow:
         mocker.patch.object(
             recoverer,
             "fetch_all_ha_states",
+            new_callable=AsyncMock,
             return_value=[{"entity_id": "sensor.s0pcmreader_1_total", "state": "5000"}],
         )
 
@@ -428,22 +453,22 @@ class TestRecoveryFlow:
 
 
 class TestRecoveryExceptions:
-    def test_fetch_ha_state_exception(self, recoverer):
+    async def test_fetch_ha_state_exception(self, recoverer):
         """Test fetch_ha_state exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
         ):
-            res = recoverer.fetch_ha_state("sensor.test")
+            res = await recoverer.fetch_ha_state("sensor.test")
             assert res is None
 
-    def test_fetch_all_ha_states_exception(self, recoverer):
+    async def test_fetch_all_ha_states_exception(self, recoverer):
         """Test fetch_all_ha_states exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
         ):
-            res = recoverer.fetch_all_ha_states()
+            res = await recoverer.fetch_all_ha_states()
             assert res == []
 
     async def test_run_recover_named_meter_gap(self, recoverer):

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -2,7 +2,7 @@
 Comprehensive tests for the recovery module.
 
 Tests cover:
-- MQTT message parsing (discovery topics, data topics, date handling)
+- Message parsing (discovery topics, data topics, date handling)
 - HA API methods (fetch_ha_state, fetch_all_ha_states)
 - Robust state cleaning logic (units, decimal separators, localization)
 - Name-to-ID mapping
@@ -11,7 +11,7 @@ Tests cover:
 
 import datetime
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from helpers import make_test_config
 import pytest
@@ -22,10 +22,11 @@ import state as state_module
 
 @pytest.fixture
 def mock_mqtt_client():
-    """Create a mock MQTT client."""
-    client = MagicMock()
-    client.subscribe = MagicMock()
-    client.unsubscribe = MagicMock()
+    """Create a mock aiomqtt Client."""
+    client = AsyncMock()
+    client.subscribe = AsyncMock()
+    client.unsubscribe = AsyncMock()
+    client.messages = AsyncMock()
     return client
 
 
@@ -40,116 +41,82 @@ def recoverer(mock_mqtt_client):
 class TestMQTTMessageParsing:
     """Test MQTT message parsing during recovery."""
 
-    def test_parse_discovery_topic_with_name(self, recoverer):
+    def test_process_message_discovery_topic_with_name(self, recoverer):
         """Test parsing discovery config messages to extract meter names."""
-        msg = MagicMock()
-        msg.topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_1_total/config"
-        msg.payload = json.dumps(
+        topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_1_total/config"
+        payload = json.dumps(
             {"unique_id": "s0pcm_s0pcmreader_1_total", "state_topic": "s0pcmreader/Water/total"}
         ).encode()
 
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message(topic, payload)
 
         assert 1 in recoverer.recovered_names
         assert recoverer.recovered_names[1] == "Water"
 
-    def test_parse_discovery_topic_ignores_id_as_name(self, recoverer):
+    def test_process_message_discovery_topic_ignores_id_as_name(self, recoverer):
         """Test that numeric IDs are not stored as names."""
-        msg = MagicMock()
-        msg.topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_2_total/config"
-        msg.payload = json.dumps(
-            {"unique_id": "s0pcm_s0pcmreader_2_total", "state_topic": "s0pcmreader/2/total"}
-        ).encode()
+        topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_2_total/config"
+        payload = json.dumps({"unique_id": "s0pcm_s0pcmreader_2_total", "state_topic": "s0pcmreader/2/total"}).encode()
 
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message(topic, payload)
 
         assert 2 not in recoverer.recovered_names
 
-    def test_parse_discovery_topic_ignores_none(self, recoverer):
+    def test_process_message_discovery_topic_ignores_none(self, recoverer):
         """Test that 'None' is not stored as a valid name."""
-        msg = MagicMock()
-        msg.topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_3_total/config"
-        msg.payload = json.dumps(
+        topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_3_total/config"
+        payload = json.dumps(
             {"unique_id": "s0pcm_s0pcmreader_3_total", "state_topic": "s0pcmreader/None/total"}
         ).encode()
 
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message(topic, payload)
 
         assert 3 not in recoverer.recovered_names
 
-    def test_parse_data_topic_total(self, recoverer):
+    def test_process_message_data_topic_total(self, recoverer):
         """Test parsing total value from MQTT data topic."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/total"
-        msg.payload = b"1234567"
-
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/1/total", b"1234567")
 
         assert "1" in recoverer.recovered_data
         assert recoverer.recovered_data["1"]["total"] == 1234567
 
-    def test_parse_data_topic_today(self, recoverer):
+    def test_process_message_data_topic_today(self, recoverer):
         """Test parsing today value from MQTT data topic."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/Water/today"
-        msg.payload = b"150"
-
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/Water/today", b"150")
 
         assert "Water" in recoverer.recovered_data
         assert recoverer.recovered_data["Water"]["today"] == 150
 
-    def test_parse_data_topic_yesterday(self, recoverer):
+    def test_process_message_data_topic_yesterday(self, recoverer):
         """Test parsing yesterday value from MQTT data topic."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/2/yesterday"
-        msg.payload = b"200"
-
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/2/yesterday", b"200")
 
         assert "2" in recoverer.recovered_data
         assert recoverer.recovered_data["2"]["yesterday"] == 200
 
-    def test_parse_data_topic_pulsecount(self, recoverer):
+    def test_process_message_data_topic_pulsecount(self, recoverer):
         """Test parsing pulsecount value from MQTT data topic."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/pulsecount"
-        msg.payload = b"42"
-
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/1/pulsecount", b"42")
 
         assert "1" in recoverer.recovered_data
         assert recoverer.recovered_data["1"]["pulsecount"] == 42
 
-    def test_parse_date_topic(self, recoverer):
+    def test_process_message_date_topic(self, recoverer):
         """Test parsing date from MQTT topic."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/date"
-        msg.payload = b"2026-01-25"
-
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/date", b"2026-01-25")
 
         assert recoverer.context.state.date == datetime.date(2026, 1, 25)
 
-    def test_parse_invalid_json_gracefully(self, recoverer):
+    def test_process_message_invalid_json_gracefully(self, recoverer):
         """Test that invalid JSON in discovery topics doesn't crash."""
-        msg = MagicMock()
-        msg.topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_1_total/config"
-        msg.payload = b"{invalid json"
-
-        # Should not raise exception
-        recoverer.on_message(None, None, msg)
+        topic = "homeassistant/sensor/s0pcmreader/s0pcm_s0pcmreader_1_total/config"
+        recoverer._process_message(topic, b"{invalid json")
 
         assert 1 not in recoverer.recovered_names
 
-    def test_parse_invalid_number_gracefully(self, recoverer):
+    def test_process_message_invalid_number_gracefully(self, recoverer):
         """Test that invalid numbers in data topics are ignored."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/1/total"
-        msg.payload = b"not_a_number"
-
-        # Should not raise exception
-        recoverer.on_message(None, None, msg)
+        recoverer._process_message("s0pcmreader/1/total", b"not_a_number")
 
         assert "1" not in recoverer.recovered_data
 
@@ -327,15 +294,21 @@ class TestRobustStateCleaning:
 class TestRecoveryFlow:
     """Test the complete recovery flow."""
 
-    def test_run_subscribes_to_topics(self, recoverer, mocker):
+    async def test_run_subscribes_to_topics(self, recoverer, mocker):
         """Test that run() subscribes to all necessary topics."""
-        mocker.patch("time.sleep")
 
-        recoverer.run()
+        # Mock messages to immediately timeout
+        async def empty_messages():
+            return
+            yield  # Make it an async generator that yields nothing
+
+        recoverer.client.messages = empty_messages()
+
+        await recoverer.run()
 
         # Verify subscriptions
-        assert recoverer.mqttc.subscribe.call_count == 6
-        topics = [c[0][0] for c in recoverer.mqttc.subscribe.call_args_list]
+        assert recoverer.client.subscribe.call_count == 6
+        topics = [c[0][0] for c in recoverer.client.subscribe.call_args_list]
         assert "s0pcmreader/+/total" in topics
         assert "s0pcmreader/+/today" in topics
         assert "s0pcmreader/+/yesterday" in topics
@@ -343,34 +316,34 @@ class TestRecoveryFlow:
         assert "s0pcmreader/date" in topics
         assert "homeassistant/sensor/s0pcmreader/#" in topics
 
-    def test_run_unsubscribes_after_recovery(self, recoverer, mocker):
+    async def test_run_unsubscribes_after_recovery(self, recoverer, mocker):
         """Test that run() unsubscribes from topics after recovery."""
-        mocker.patch("time.sleep")
 
-        recoverer.run()
+        async def empty_messages():
+            return
+            yield
+
+        recoverer.client.messages = empty_messages()
+
+        await recoverer.run()
 
         # Verify unsubscriptions
-        assert recoverer.mqttc.unsubscribe.call_count == 6
+        assert recoverer.client.unsubscribe.call_count == 6
 
-    def test_run_restores_original_on_message(self, recoverer, mocker):
-        """Test that run() restores the original on_message handler."""
-        mocker.patch("time.sleep")
-        original_handler = MagicMock()
-        recoverer.mqttc.on_message = original_handler
-
-        recoverer.run()
-
-        assert recoverer.mqttc.on_message == original_handler
-
-    def test_run_initializes_meters_from_mqtt_data(self, recoverer, mocker):
+    async def test_run_initializes_meters_from_mqtt_data(self, recoverer, mocker):
         """Test that run() initializes meters from recovered MQTT data."""
-        mocker.patch("time.sleep")
+
+        async def empty_messages():
+            return
+            yield
+
+        recoverer.client.messages = empty_messages()
 
         # Simulate recovered data
         recoverer.recovered_data = {"1": {"total": 1000, "today": 50, "yesterday": 40, "pulsecount": 10}}
         recoverer.recovered_names = {1: "Water"}
 
-        recoverer.run()
+        await recoverer.run()
 
         assert 1 in recoverer.context.state.meters
         meter = recoverer.context.state.meters[1]
@@ -380,20 +353,31 @@ class TestRecoveryFlow:
         assert meter.yesterday == 40
         assert meter.pulsecount == 10
 
-    def test_run_skips_zero_only_data(self, recoverer, mocker):
+    async def test_run_skips_zero_only_data(self, recoverer, mocker):
         """Test that run() doesn't initialize meters with only zero values."""
-        mocker.patch("time.sleep")
+
+        async def empty_messages():
+            return
+            yield
+
+        recoverer.client.messages = empty_messages()
 
         # Simulate recovered data with all zeros
         recoverer.recovered_data = {"1": {"total": 0, "today": 0, "yesterday": 0, "pulsecount": 0}}
 
-        recoverer.run()
+        await recoverer.run()
 
         assert 1 not in recoverer.context.state.meters
 
-    def test_run_uses_ha_api_fallback(self, recoverer, mocker):
+    async def test_run_uses_ha_api_fallback(self, recoverer, mocker):
         """Test that run() uses HA API fallback for missing totals."""
-        mocker.patch("time.sleep")
+
+        async def empty_messages():
+            return
+            yield
+
+        recoverer.client.messages = empty_messages()
+
         mocker.patch.object(
             recoverer,
             "fetch_all_ha_states",
@@ -403,21 +387,20 @@ class TestRecoveryFlow:
         # Initialize meter with zero total
         recoverer.context.state.meters[1] = state_module.MeterState()
 
-        recoverer.run()
+        await recoverer.run()
 
         assert recoverer.context.state.meters[1].total == 5000
 
         meter = recoverer.context.state.meters[1]
-        assert meter.name is None  # Name not recovered/set in this test
-        # These fields are not updated by fetch_all_ha_states (only totals)
-        assert meter.today == 0  # Default
-        assert meter.yesterday == 0  # Default
-        assert meter.pulsecount == 0  # Default
+        assert meter.name is None
+        assert meter.today == 0
+        assert meter.yesterday == 0
+        assert meter.pulsecount == 0
 
 
 class TestRecoveryExceptions:
     def test_fetch_ha_state_exception(self, recoverer):
-        """Test fetch_ha_state exception handling (lines 48-49)."""
+        """Test fetch_ha_state exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
@@ -426,7 +409,7 @@ class TestRecoveryExceptions:
             assert res is None
 
     def test_fetch_all_ha_states_exception(self, recoverer):
-        """Test fetch_all_ha_states exception handling (lines 65-67)."""
+        """Test fetch_all_ha_states exception handling."""
         with (
             patch("os.getenv", return_value="TOKEN"),
             patch("urllib.request.urlopen", side_effect=Exception("API Error")),
@@ -434,23 +417,25 @@ class TestRecoveryExceptions:
             res = recoverer.fetch_all_ha_states()
             assert res == []
 
-    def test_run_recover_named_meter_gap(self, recoverer):
-        """Test recovering a meter by name that isn't in main state yet (lines 160-162)."""
+    async def test_run_recover_named_meter_gap(self, recoverer):
+        """Test recovering a meter by name that isn't in main state yet."""
         recoverer.recovered_names = {10: "Garage"}
-        # No recovered data for 10, so it won't be created by ID loop
 
-        with patch("time.sleep"):
-            recoverer.run()
+        async def empty_messages():
+            return
+            yield
+
+        recoverer.client.messages = empty_messages()
+
+        await recoverer.run()
 
         context = state_module.get_context()
         assert 10 in context.state.meters
         assert context.state.meters[10].name == "Garage"
 
     def test_find_total_chaos_format(self, recoverer):
-        """Test _find_total_in_ha with chaos format (line 249)."""
-        # "1.1.1,1,1" -> chaos -> "11111"
+        """Test _find_total_in_ha with chaos format."""
         states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": "1.1.1,1,1"}]
-        # We need a meter in state for _find_total_in_ha to work (it gets name from there)
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState()
 
@@ -458,7 +443,7 @@ class TestRecoveryExceptions:
         assert val == 11111
 
     def test_find_total_empty(self, recoverer):
-        """Test _find_total_in_ha with empty string (line 257)."""
+        """Test _find_total_in_ha with empty string."""
         states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": " "}]
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState()
@@ -467,8 +452,7 @@ class TestRecoveryExceptions:
         assert val is None
 
     def test_find_total_value_error(self, recoverer):
-        """Test _find_total_in_ha with invalid number (lines 259-260)."""
-        # "." passes the digit/sep filter but fails float conversion
+        """Test _find_total_in_ha with invalid number."""
         states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": "."}]
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState()
@@ -476,23 +460,13 @@ class TestRecoveryExceptions:
         val = recoverer._find_total_in_ha(1, states)
         assert val is None
 
-    def test_on_message_date_error(self, recoverer):
-        """Test on_message date parsing error (lines 106-107)."""
-        msg = MagicMock()
-        msg.topic = "s0pcmreader/date"
-        msg.payload = b"invalid-date"
-
-        # Should not raise
-        recoverer.on_message(None, None, msg)
+    def test_process_message_date_error(self, recoverer):
+        """Test _process_message date parsing error."""
+        recoverer._process_message("s0pcmreader/date", b"invalid-date")
         assert recoverer.context.state.date != "invalid-date"
 
     def test_find_total_complex_US(self, recoverer):
-        """Test _find_total_in_ha with US format 1,000.50 (lines 245-246)."""
-        # Comma > Dot? 1 comma, 1 dot. Equal.
-        # Line 239: count(.) == 1 and count(,) == 1
-        # Line 241: find(.) < find(,) (EU) vs else (US)
-        # 1,000.50 -> find(,) vs find(.) -> index 1 vs 5 -> Comma first.
-        # US: remove ',' -> 1000.50 -> int(float) -> 1000
+        """Test _find_total_in_ha with US format 1,000.50."""
         states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": "1,000.50"}]
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState()
@@ -501,9 +475,7 @@ class TestRecoveryExceptions:
         assert val == 1000
 
     def test_find_total_complex_EU(self, recoverer):
-        """Test _find_total_in_ha with EU format 1.000,50 (lines 242-243)."""
-        # 1.000,50 -> Dot first -> EU
-        # replace . -> 1000,50 -> replace , back to . -> 1000.50 -> 1000
+        """Test _find_total_in_ha with EU format 1.000,50."""
         states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": "1.000,50"}]
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState()
@@ -512,9 +484,14 @@ class TestRecoveryExceptions:
         assert val == 1000
 
 
-def test_run_name_data_merge(recoverer, mocker):
-    """Test name-based data merging with max() logic (lines 169-172)."""
-    mocker.patch("time.sleep")
+async def test_run_name_data_merge(recoverer, mocker):
+    """Test name-based data merging with max() logic."""
+
+    async def empty_messages():
+        return
+        yield
+
+    recoverer.client.messages = empty_messages()
 
     # Setup: meter with name and data under name topic
     recoverer.recovered_names = {1: "WaterMeter"}
@@ -523,7 +500,7 @@ def test_run_name_data_merge(recoverer, mocker):
         "WaterMeter": {"total": 150, "today": 15, "yesterday": 5, "pulsecount": 20},
     }
 
-    recoverer.run()
+    await recoverer.run()
 
     meter = recoverer.context.state.meters[1]
     assert meter.name == "WaterMeter"
@@ -533,7 +510,7 @@ def test_run_name_data_merge(recoverer, mocker):
 
 
 def test_find_total_many_commas(recoverer):
-    """Test number parsing with many commas (line 235)."""
+    """Test number parsing with many commas."""
     states = [{"entity_id": "sensor.s0pcmreader_1_total", "state": "1,000,000"}]
     context = state_module.get_context()
     context.state.meters[1] = state_module.MeterState()

--- a/tests/test_s0pcm_reader.py
+++ b/tests/test_s0pcm_reader.py
@@ -2,7 +2,8 @@
 Tests for main module (s0pcm_reader.py).
 """
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -52,6 +53,60 @@ def test_init_args_coverage():
         mock_parse.return_value.config = "/tmp/test"
         result_path = config_module_imp.init_args()
         assert str(result_path) == "/tmp/test"
+
+
+async def test_main_signal_handler(mocker):
+    """Test signal handler registration and execution."""
+    import s0pcm_reader
+
+    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.mqtt_task", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.logger")
+
+    mock_loop = MagicMock()
+    mocker.patch("asyncio.get_running_loop", return_value=mock_loop)
+
+    mock_task = MagicMock()
+    mocker.patch("asyncio.all_tasks", return_value={mock_task})
+
+    await s0pcm_reader.main()
+
+    # Verify add_signal_handler was called for SIGINT and SIGTERM
+    assert mock_loop.add_signal_handler.call_count == 2
+
+    # Extract the registered signal handler function
+    sig_handler = mock_loop.add_signal_handler.call_args[0][1]
+
+    # Call the signal handler
+    sig_handler()
+
+    # Verify it cancelled the tasks
+    mock_task.cancel.assert_called_once()
+
+
+async def test_main_cancellation_handling(mocker):
+    """Test that main() handles CancelledError ExceptionGroup gracefully."""
+    import s0pcm_reader
+
+    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.logger")
+
+    # Mock TaskGroup to raise BaseExceptionGroup containing CancelledError
+    class MockTaskGroup:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            raise BaseExceptionGroup("group", [asyncio.CancelledError()])
+
+        def create_task(self, coro):
+            pass
+
+    mocker.patch("asyncio.TaskGroup", return_value=MockTaskGroup())
+
+    # This should run without raising because BaseExceptionGroup containing CancelledError is caught by except*
+    await s0pcm_reader.main()
 
 
 if __name__ == "__main__":

--- a/tests/test_s0pcm_reader.py
+++ b/tests/test_s0pcm_reader.py
@@ -12,7 +12,8 @@ async def test_main_initialization(mocker):
     """Test that main() initializes config and starts tasks."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
 
     # Mock serial_task and mqtt_task as async functions
     mock_serial_task = mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
@@ -23,9 +24,7 @@ async def test_main_initialization(mocker):
     await s0pcm_reader.main()
 
     # Verify read_config was called
-    import config as config_module_imp
-
-    config_module_imp.read_config.assert_called_once()
+    s0pcm_reader.config_module.read_config.assert_called_once()
 
     # Verify tasks were started (called as coroutines in TaskGroup)
     mock_serial_task.assert_called_once()
@@ -36,7 +35,10 @@ async def test_main_config_exception_exit(mocker):
     """Test main exit on config exception."""
     import s0pcm_reader
 
-    mocker.patch("s0pcm_reader.config_module.read_config", side_effect=Exception("Config Error"))
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch(
+        "s0pcm_reader.config_module.read_config", new_callable=AsyncMock, side_effect=Exception("Config Error")
+    )
     mocker.patch("s0pcm_reader.logger")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -59,7 +61,8 @@ async def test_main_signal_handler(mocker):
     """Test signal handler registration and execution."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.mqtt_task", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.logger")
@@ -89,7 +92,8 @@ async def test_main_cancellation_handling(mocker):
     """Test that main() handles CancelledError ExceptionGroup gracefully."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
+    mocker.patch("s0pcm_reader.get_version", new_callable=AsyncMock)
+    mocker.patch("s0pcm_reader.config_module.read_config", new_callable=AsyncMock)
     mocker.patch("s0pcm_reader.logger")
 
     # Mock TaskGroup to raise BaseExceptionGroup containing CancelledError

--- a/tests/test_s0pcm_reader.py
+++ b/tests/test_s0pcm_reader.py
@@ -2,139 +2,52 @@
 Tests for main module (s0pcm_reader.py).
 """
 
-import signal
-import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# import s0pcm_reader - lazy imported
 
-
-def test_main_initialization(mocker):
+async def test_main_initialization(mocker):
     """Test that main() initializes config and starts tasks."""
     import s0pcm_reader
 
-    # Mock dependencies to prevent real initialization or threads
     mocker.patch("config.read_config")
-    mock_t1_class = mocker.patch("s0pcm_reader.TaskReadSerial")
-    mock_t2_class = mocker.patch("s0pcm_reader.TaskDoMQTT")
-    mocker.patch("signal.signal")
 
-    mock_t1 = MagicMock()
-    mock_t2 = MagicMock()
+    # Mock serial_task and mqtt_task as async functions
+    mock_serial_task = mocker.patch("s0pcm_reader.serial_task", new_callable=AsyncMock)
+    mock_mqtt_task = mocker.patch("s0pcm_reader.mqtt_task", new_callable=AsyncMock)
 
-    # Make them 'not alive' immediately so main exits
-    mocker.patch("time.sleep")  # Prevent sleep delays
-
-    # Needs to simulate being alive initially to enter loop, then dead to exit
-    # OR, since main() waits for them to be alive, we can just make them dead immediately
-    # IF the logic is "while t1.is_alive()..."
-    # Let's check main.py logic. Assuming it waits for threads to be *started* or *alive*.
-    # Actually, main usually does: t1.start(); t2.start(); while t1.is_alive() and t2.is_alive(): ...
-
-    # So to exit the loop, one of them must return False.
-    # So to exit the loop, one of them must return False eventually.
-    # To run the loop body at least once (if needed), side_effect=[True, False]
-    # This ensures lines 80-82 are covered.
-    # Iter 1: t1=True (enters loop)
-    # Iter 2: t1=False, t2=False (exits loop)
-    mock_t1.is_alive.side_effect = [True, False]
-    mock_t2.is_alive.return_value = False
-
-    mock_t1_class.return_value = mock_t1
-    mock_t2_class.return_value = mock_t2
-
-    # Patch logger to avoid stdout pollution
     mocker.patch("s0pcm_reader.logger")
 
-    # Call main
-    s0pcm_reader.main()
+    await s0pcm_reader.main()
 
     # Verify read_config was called
     import config as config_module_imp
 
     config_module_imp.read_config.assert_called_once()
 
-    # Verify tasks were created and started
-    mock_t1_class.assert_called_once()
-    mock_t1.start.assert_called_once()
-    mock_t2_class.assert_called_once()
-    mock_t2.start.assert_called_once()
+    # Verify tasks were started (called as coroutines in TaskGroup)
+    mock_serial_task.assert_called_once()
+    mock_mqtt_task.assert_called_once()
 
 
-def test_signal_handler(mocker):
-    """Test the internal signal handler sets stopper and trigger."""
+async def test_main_config_exception_exit(mocker):
+    """Test main exit on config exception."""
     import s0pcm_reader
 
-    mocker.patch("config.read_config")
-    mocker.patch("s0pcm_reader.TaskReadSerial")
-    mocker.patch("s0pcm_reader.TaskDoMQTT")
-    mocker.patch("s0pcm_reader.logger")
-
-    # Mock signal.signal to capture the handler
-    captured_handler = None
-
-    def mock_signal_call(sig, handler):
-        nonlocal captured_handler
-        captured_handler = handler
-
-    mocker.patch("signal.signal", side_effect=mock_signal_call)
-
-    # We need to mock the alive status to exit main (run once then stop)
-    mock_t1 = MagicMock()
-    mock_t1.is_alive.side_effect = [True, False]
-    mocker.patch("s0pcm_reader.TaskReadSerial", return_value=mock_t1)
-
-    # Needs to be mocked to return something that isn't alive to exit loop
-    mocker.patch("s0pcm_reader.TaskDoMQTT", return_value=MagicMock(is_alive=lambda: False))
-
-    # Instantiate global mocks for main to use
-    s0pcm_reader.stopper = threading.Event()
-    s0pcm_reader.trigger = threading.Event()
-
-    # Call main to set up the handler
-    s0pcm_reader.main()
-
-    # Now verify the handler logic (it should set stopper and trigger)
-    assert captured_handler is not None
-
-    captured_handler(signal.SIGINT, None)
-
-    assert s0pcm_reader.stopper.is_set()
-    assert s0pcm_reader.trigger.is_set()
-
-
-def test_main_config_exception_exit(mocker):
-    """Test main exit on config exception (lines 60-62)."""
-    import s0pcm_reader
-
-    # Defensive: Mock tasks to be dead on arrival, preventing infinite loop in main
-    # if the exception is missed.
-    mock_t1_cls = mocker.patch("s0pcm_reader.TaskReadSerial")
-    mock_t2_cls = mocker.patch("s0pcm_reader.TaskDoMQTT")
-
-    # Ensure instances created from these classes return False for is_alive()
-    # explicitly setting return_value on the method mock.
-    mock_t1_cls.return_value.is_alive.return_value = False
-    mock_t2_cls.return_value.is_alive.return_value = False
-
-    # Patch the exact reference used in s0pcm_reader
-    # s0pcm_reader.py does 'import config as config_module'
     mocker.patch("s0pcm_reader.config_module.read_config", side_effect=Exception("Config Error"))
     mocker.patch("s0pcm_reader.logger")
 
     with pytest.raises(SystemExit) as excinfo:
-        s0pcm_reader.main()
+        await s0pcm_reader.main()
 
     assert excinfo.value.code == 1
 
 
 def test_init_args_coverage():
-    """Test init_args function coverage (line 55)."""
+    """Test init_args function coverage."""
     import config as config_module_imp
 
-    # init_args was inlined; test config_module.init_args directly
     with patch("argparse.ArgumentParser.parse_args") as mock_parse:
         mock_parse.return_value.config = "/tmp/test"
         result_path = config_module_imp.init_args()

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -22,11 +22,11 @@ import state as state_module
 
 
 @pytest.fixture(autouse=True)
-def setup_serial_test_state():
+async def setup_serial_test_state():
     """Ensure a clean state for every test."""
     context = state_module.get_context()
     # Initialize basic config using standard logic
-    context.config = config_module.read_config(version="test")
+    context.config = await config_module.read_config(version="test")
     context.s0pcm_firmware = "Unknown"
     context.state.reset_state()
     context.lasterror_serial = None
@@ -41,7 +41,7 @@ def s0pcm_packets():
 
 
 class TestSerialPacketParsing:
-    def test_handle_data_packet_updates_measurement(self, s0pcm_packets, mocker):
+    async def test_handle_data_packet_updates_measurement(self, s0pcm_packets, mocker):
         context = state_module.get_context()
         mocker.patch.object(context, "set_error")
 
@@ -51,7 +51,7 @@ class TestSerialPacketParsing:
         assert 1 in context.state.meters
         assert context.state.meters[1].total == 100
 
-    def test_invalid_packet_sets_error(self, s0pcm_packets, mocker):
+    async def test_invalid_packet_sets_error(self, s0pcm_packets, mocker):
         context = state_module.get_context()
         mock_set_error = mocker.patch.object(context, "set_error")
         _handle_data_packet(context, "ID:8237:I:10:M1:0:100")  # Too short
@@ -59,7 +59,7 @@ class TestSerialPacketParsing:
 
 
 class TestPulseCountLogic:
-    def test_pulse_increment(self):
+    async def test_pulse_increment(self):
         # Initialize meter properly using state_module models
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
@@ -67,14 +67,14 @@ class TestPulseCountLogic:
         assert context.state.meters[1].total == 1010
         assert context.state.meters[1].today == 60
 
-    def test_pulse_reset_detection(self):
+    async def test_pulse_reset_detection(self):
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
         _update_meter(context, 1, 10, 10, 20)  # Restarted (pulsecount reset to 10)
         # Total should increase by 10
         assert context.state.meters[1].total == 1010
 
-    def test_pulse_anomaly(self):
+    async def test_pulse_anomaly(self):
         """Test pulsecount anomaly (lower but not 0)."""
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000)
@@ -85,7 +85,7 @@ class TestPulseCountLogic:
         # Logic: delta = pulsecount (90). Total += 90.
         assert context.state.meters[1].total == 1090
 
-    def test_update_meter_uninitialized(self):
+    async def test_update_meter_uninitialized(self):
         context = state_module.AppContext()
         _update_meter(context, 1, 5, 5, 10)
         assert 1 in context.state.meters
@@ -93,7 +93,7 @@ class TestPulseCountLogic:
 
 
 class TestSerialPacketAdvanced:
-    def test_handle_header_parsing(self):
+    async def test_handle_header_parsing(self):
         context = state_module.get_context()
 
         _handle_header(context, "/8237:S0 Pulse Counter V0.6")
@@ -140,7 +140,7 @@ class TestSerialPacketAdvanced:
 
 
 class TestDayChange:
-    def test_day_change_resets_today(self):
+    async def test_day_change_resets_today(self):
         context = state_module.get_context()
         yesterday = datetime.date.today() - datetime.timedelta(days=1)
         # Set date in state
@@ -154,7 +154,7 @@ class TestDayChange:
         assert context.state.date == datetime.date.today()
 
 
-def test_handle_header_fallback():
+async def test_handle_header_fallback():
     """Test _handle_header fallback paths."""
     context = state_module.get_context()
 
@@ -179,7 +179,7 @@ def test_handle_header_fallback():
     assert context.s0pcm_firmware == bad_str
 
 
-def test_update_meter_reset_logging():
+async def test_update_meter_reset_logging():
     """Test _update_meter reset logging."""
     context = state_module.get_context()
     context.state.meters[1] = state_module.MeterState(total=1000, pulsecount=500)
@@ -302,7 +302,7 @@ async def test_serial_task_exclusive_mode(mocker):
     assert kwargs["exclusive"] is True
 
 
-def test_log_available_ports_with_ports():
+async def test_log_available_ports_with_ports():
     """Test _log_available_ports when ports are detected."""
     mock_port = MagicMock()
     mock_port.device = "/dev/ttyACM0"
@@ -310,28 +310,28 @@ def test_log_available_ports_with_ports():
         patch("serialx.list_serial_ports", return_value=[mock_port]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert any("/dev/ttyACM0" in str(c) for c in mock_logger.info.call_args_list)
 
 
-def test_log_available_ports_no_ports():
+async def test_log_available_ports_no_ports():
     """Test _log_available_ports when no ports are detected."""
     with (
         patch("serialx.list_serial_ports", return_value=[]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert mock_logger.warning.called
         assert "No serial ports detected" in mock_logger.warning.call_args[0][0]
 
 
-def test_log_available_ports_exception():
+async def test_log_available_ports_exception():
     """Test _log_available_ports handles exceptions gracefully."""
     with (
         patch("serialx.list_serial_ports", side_effect=OSError("Permission denied")),
         patch("serial_handler.logger") as mock_logger,
     ):
-        _log_available_ports()
+        await _log_available_ports()
         assert mock_logger.debug.called
         assert "Unable to enumerate" in mock_logger.debug.call_args[0][0]
 
@@ -353,7 +353,7 @@ async def test_log_available_ports_called_on_first_failure(mocker):
 
     mocker.patch("serialx.async_serial_for_url", side_effect=fail_then_cancel)
     mocker.patch("asyncio.sleep", return_value=None)
-    mock_log_ports = mocker.patch("serial_handler._log_available_ports")
+    mock_log_ports = mocker.patch("serial_handler._log_available_ports", new_callable=AsyncMock)
 
     # serial_task catches CancelledError internally and returns
     await serial_task(context)

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -2,17 +2,22 @@
 Tests for serial handler module (serial_handler.py).
 """
 
+import asyncio
 import datetime
-import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from helpers import make_test_config
 import pytest
-import serialx
 
 import config as config_module
-from config import SerialConfig
-from serial_handler import TaskReadSerial
+from serial_handler import (
+    _handle_data_packet,
+    _handle_header,
+    _log_available_ports,
+    _read_loop,
+    _update_meter,
+    serial_task,
+)
 import state as state_module
 
 
@@ -28,12 +33,6 @@ def setup_serial_test_state():
 
 
 @pytest.fixture
-def mock_serial():
-    with patch("serialx.serial_for_url") as mock:
-        yield mock
-
-
-@pytest.fixture
 def s0pcm_packets():
     return {
         "s0pcm2_data": b"ID:8237:I:10:M1:0:100:M2:0:200\r\n",
@@ -44,21 +43,18 @@ def s0pcm_packets():
 class TestSerialPacketParsing:
     def test_handle_data_packet_updates_measurement(self, s0pcm_packets, mocker):
         context = state_module.get_context()
-        task = TaskReadSerial(context, threading.Event(), threading.Event())
-        mocker.patch.object(task.app_context, "set_error")
+        mocker.patch.object(context, "set_error")
 
         data_str = s0pcm_packets["s0pcm2_data"].decode("ascii").rstrip("\r\n")
-        task._handle_data_packet(data_str)
+        _handle_data_packet(context, data_str)
 
-        context = state_module.get_context()
         assert 1 in context.state.meters
         assert context.state.meters[1].total == 100
 
     def test_invalid_packet_sets_error(self, s0pcm_packets, mocker):
         context = state_module.get_context()
-        task = TaskReadSerial(context, threading.Event(), threading.Event())
-        mock_set_error = mocker.patch.object(task.app_context, "set_error")
-        task._handle_data_packet("ID:8237:I:10:M1:0:100")  # Too short
+        mock_set_error = mocker.patch.object(context, "set_error")
+        _handle_data_packet(context, "ID:8237:I:10:M1:0:100")  # Too short
         assert mock_set_error.called
 
 
@@ -67,36 +63,31 @@ class TestPulseCountLogic:
         # Initialize meter properly using state_module models
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
-        task = TaskReadSerial(context, None, None)
-        task._update_meter(1, 110, 10, 10)
+        _update_meter(context, 1, 110, 10, 10)
         assert context.state.meters[1].total == 1010
         assert context.state.meters[1].today == 60
 
     def test_pulse_reset_detection(self):
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
-        task = TaskReadSerial(context, None, None)
-        task._update_meter(1, 10, 10, 20)  # Restarted (pulsecount reset to 10)
+        _update_meter(context, 1, 10, 10, 20)  # Restarted (pulsecount reset to 10)
         # Total should increase by 10
         assert context.state.meters[1].total == 1010
 
     def test_pulse_anomaly(self):
-        """Test pulsecount anomaly (lower but not 0) (lines 162-165)."""
+        """Test pulsecount anomaly (lower but not 0)."""
         context = state_module.get_context()
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000)
-        task = TaskReadSerial(context, None, None)
-        task._update_meter(1, 90, 0, 10)  # Lower than 100, not 0
+        _update_meter(context, 1, 90, 0, 10)  # Lower than 100, not 0
         # Should record error
         assert context.lasterror_serial is not None
         assert "Pulsecount anomaly" in context.lasterror_serial
-        # Should NOT increase total (delta is 90? No, delta is new pulsecount if < old?)
-        # Logic: delta = pulsecount (line 167). Total += 90.
+        # Logic: delta = pulsecount (90). Total += 90.
         assert context.state.meters[1].total == 1090
 
     def test_update_meter_uninitialized(self):
         context = state_module.AppContext()
-        task = TaskReadSerial(context, None, None)
-        task._update_meter(1, 5, 5, 10)
+        _update_meter(context, 1, 5, 5, 10)
         assert 1 in context.state.meters
         assert context.state.meters[1].total == 5
 
@@ -104,54 +95,48 @@ class TestPulseCountLogic:
 class TestSerialPacketAdvanced:
     def test_handle_header_parsing(self):
         context = state_module.get_context()
-        task = TaskReadSerial(context, None, None)
 
-        # Verify context identity
-        assert task.app_context is context
-        assert task.app_context is state_module.get_context()
-
-        task._handle_header("/8237:S0 Pulse Counter V0.6")
+        _handle_header(context, "/8237:S0 Pulse Counter V0.6")
         assert context.s0pcm_firmware == "S0 Pulse Counter V0.6"
 
-    def test_read_loop_decoding_error(self, mocker):
-        mock_ser = MagicMock()
-        mock_ser.readline.side_effect = [b"\xff\xfe\xfd", b""]
+    async def test_read_loop_decoding_error(self, mocker):
+        mock_ser = AsyncMock()
+        mock_ser.readline = AsyncMock(side_effect=[b"\xff\xfe\xfd", b""])
         context = state_module.get_context()
-        task = TaskReadSerial(context, None, threading.Event())
-        mock_set_error = mocker.patch.object(task.app_context, "set_error")
-        task._read_loop(mock_ser)
+        mock_set_error = mocker.patch.object(context, "set_error")
+        await _read_loop(context, mock_ser)
         assert any("Failed to decode" in str(c) for c in mock_set_error.call_args_list)
 
-    def test_read_loop_bounded_read(self):
+    async def test_read_loop_bounded_read(self):
         """Test that readline is called with a size limit (DoS prevention)."""
-        mock_ser = MagicMock()
-        mock_ser.readline.side_effect = [b""]  # Return empty to exit loop immediately (timeout path)
+        mock_ser = AsyncMock()
+        mock_ser.readline = AsyncMock(return_value=b"")  # Return empty to exit loop immediately (timeout path)
         context = state_module.get_context()
-        task = TaskReadSerial(context, None, threading.Event())
 
-        task._read_loop(mock_ser)
+        await _read_loop(context, mock_ser)
 
-        # Verify readline was called with an integer argument (size limit)
-        mock_ser.readline.assert_called_with(512)
+        # Verify readline was called
+        mock_ser.readline.assert_called_with()
 
-    def test_serial_connect_success(self, mock_serial, mocker):
-        # Setup config
+    async def test_serial_task_connect_success(self, mocker):
+        """Test serial_task opens port and calls read loop."""
         context = state_module.get_context()
         context.config = make_test_config()
-
-        stopper = threading.Event()
-        task = TaskReadSerial(context, None, stopper)
         context.recovery_event.set()
 
-        def stop_logic(ser):
-            stopper.set()
+        mock_ser = AsyncMock()
+        mock_ser.__aenter__ = AsyncMock(return_value=mock_ser)
+        mock_ser.__aexit__ = AsyncMock(return_value=False)
+        mocker.patch("serialx.async_serial_for_url", return_value=mock_ser)
 
-        mocker.patch.object(task, "_read_loop", side_effect=stop_logic)
-        mock_serial.return_value = MagicMock()
+        # Make _read_loop cancel the task after one call
+        async def cancel_after_read(ctx, ser):
+            raise asyncio.CancelledError()
 
-        task.run()
+        mocker.patch("serial_handler._read_loop", side_effect=cancel_after_read)
 
-        mock_serial.assert_called_once()
+        # serial_task catches CancelledError and returns normally
+        await serial_task(context)
 
 
 class TestDayChange:
@@ -162,68 +147,22 @@ class TestDayChange:
         context.state.date = yesterday
         context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
 
-        task = TaskReadSerial(context, None, None)
-        task._update_meter(1, 110, 10, 10)
+        _update_meter(context, 1, 110, 10, 10)
 
         assert context.state.meters[1].yesterday == 50
         assert context.state.meters[1].today == 10
         assert context.state.date == datetime.date.today()
 
 
-# --- From test_serial_missing.py ---
-
-
-@pytest.fixture
-def serial_task_missing():
-    trigger = MagicMock()
-    stopper = MagicMock()
-    stopper.is_set.return_value = False
-
+def test_handle_header_fallback():
+    """Test _handle_header fallback paths."""
     context = state_module.get_context()
-    context.config = make_test_config()
-    context.config = context.config.model_copy(
-        update={
-            "serial": SerialConfig(
-                port="/dev/ttyTEST",
-                baudrate=9600,
-                parity=serialx.PARITY_NONE,
-                stopbits=serialx.STOPBITS_ONE,
-                bytesize=serialx.EIGHTBITS,
-                timeout=1,
-                connect_retry=1,
-            )
-        }
-    )
-    context.state.meters = {}
-    context.lasterror_serial = None
 
-    return TaskReadSerial(context, trigger, stopper)
+    # Test strict slicing fallback (no colon)
+    _handle_header(context, "/SIMPLE")
+    assert context.s0pcm_firmware == "SIMPLE"
 
-
-def test_run_exception_retry(serial_task_missing, mocker):
-    """Test run() exception handling and retry."""
-
-    serial_task_missing._stopper.is_set.side_effect = [False, True]
-    serial_task_missing.app_context.recovery_event.set()
-
-    mocker.patch("serialx.serial_for_url", side_effect=Exception("Connection Failed"))
-    mock_sleep = mocker.patch("time.sleep")
-    mocker.patch.object(serial_task_missing, "_log_available_ports")
-
-    serial_task_missing.run()
-
-    assert mock_sleep.called
-    assert serial_task_missing.app_context.lasterror_serial is not None
-    assert "Connection Failed" in serial_task_missing.app_context.lasterror_serial
-
-
-def test_handle_header_fallback(serial_task_missing):
-    """Test _handle_header fallback paths (lines 86-88)."""
-    # Test strict slicing fallback (line 84)
-    serial_task_missing._handle_header("/SIMPLE")
-    assert serial_task_missing.app_context.s0pcm_firmware == "SIMPLE"
-
-    # Test exception fallback (line 86-87)
+    # Test exception fallback
     class BadString:
         def __contains__(self, item):
             return True  # trigger first branch
@@ -235,101 +174,135 @@ def test_handle_header_fallback(serial_task_missing):
             return "BadString"
 
     bad_str = BadString()
-    serial_task_missing._handle_header(bad_str)
+    _handle_header(context, bad_str)
     # Should fall back to assigning the object itself
-    assert serial_task_missing.app_context.s0pcm_firmware == bad_str
+    assert context.s0pcm_firmware == bad_str
 
 
-def test_update_meter_reset_logging(serial_task_missing):
-    """Test _update_meter reset logging (line 156)."""
+def test_update_meter_reset_logging():
+    """Test _update_meter reset logging."""
     context = state_module.get_context()
     context.state.meters[1] = state_module.MeterState(total=1000, pulsecount=500)
 
     # Pulsecount 0 triggers reset logic
     with patch("serial_handler.logger"):
-        serial_task_missing._update_meter(1, 0, 0, 10)
+        _update_meter(context, 1, 0, 0, 10)
 
         assert context.lasterror_serial is not None
         assert "S0PCM Reset detected" in context.lasterror_serial
 
 
-def test_read_loop_errors(serial_task_missing):
-    """Test _read_loop read error and junk packet (lines 182-184, 204)."""
-    mock_serial = MagicMock()
+async def test_read_loop_read_error():
+    """Test _read_loop breaks on read exception."""
+    context = state_module.get_context()
 
-    # 1. Read Error (causes break)
-    mock_serial.readline.side_effect = Exception("Read IO Error")
+    mock_serial = AsyncMock()
+    mock_serial.readline = AsyncMock(side_effect=Exception("Read IO Error"))
 
-    serial_task_missing._read_loop(mock_serial)
-    assert "Serialport read error" in serial_task_missing.app_context.lasterror_serial
-
-    # Reset for next part
-    serial_task_missing.app_context.lasterror_serial = None
-    serial_task_missing._stopper.is_set.side_effect = [False, True]  # Run once
-
-    # 2. Junk Packet (lines 204)
-    mock_serial.readline.side_effect = [b"JUNK_DATA\r\n"]
-
-    serial_task_missing._read_loop(mock_serial)
-    assert "Invalid Packet: 'JUNK_DATA'" in serial_task_missing.app_context.lasterror_serial
+    await _read_loop(context, mock_serial)
+    assert "Serialport read error" in context.lasterror_serial
 
 
-def test_run_fatal_exception(serial_task_missing, mocker):
-    """Test run fatal exception (line 219-220)."""
-    # Force exception at start of run
-    mocker.patch.object(serial_task_missing.app_context.recovery_event, "wait", side_effect=Exception("Fatal Error"))
+async def test_read_loop_junk_packet(mocker):
+    """Test _read_loop handles junk packet."""
+    context = state_module.get_context()
+    mock_set_error = mocker.patch.object(context, "set_error")
 
-    with patch("serial_handler.logger.error") as mock_logger:
-        serial_task_missing.run()
+    mock_serial = AsyncMock()
+    mock_serial.readline = AsyncMock(side_effect=[b"JUNK_DATA\r\n", b""])
 
-        assert mock_logger.called
-        assert "Fatal exception in Serial Task" in mock_logger.call_args[0][0]
-        assert serial_task_missing._stopper.set.called
+    await _read_loop(context, mock_serial)
+
+    # Verify set_error was called with the junk packet error
+    error_calls = [str(c) for c in mock_set_error.call_args_list]
+    assert any("Invalid Packet" in c and "JUNK_DATA" in c for c in error_calls)
 
 
-def test_read_loop_header(serial_task_missing):
-    """Test _read_loop header handling (lines 197-204)."""
-    mock_serial = MagicMock()
-    # 1. Header (hits 197-198)
-    # 2. ID Packet (hits 199-200)
-    # 3. Empty string decoded (hits 201-202)
-    # 4. Empty bytes (hits 186 -> break)
-    mock_serial.readline.side_effect = [b"/HEADER:V1\r\n", b"ID:123\r\n", b"\r\n", b""]
+async def test_serial_task_fatal_exception(mocker):
+    """Test serial_task fatal exception."""
+    context = state_module.get_context()
+    context.config = make_test_config()
+    context.recovery_event.set()
+
+    mocker.patch("serialx.async_serial_for_url", side_effect=Exception("Fatal Error"))
+    mocker.patch("asyncio.sleep", side_effect=asyncio.CancelledError())
+
+    # serial_task catches CancelledError internally and returns
+    await serial_task(context)
+
+    assert context.lasterror_serial is not None
+    assert "Fatal Error" in context.lasterror_serial
+
+
+async def test_serial_task_retry_on_failure(mocker):
+    """Test serial_task retries on connection failure."""
+    context = state_module.get_context()
+    context.config = make_test_config()
+    context.recovery_event.set()
+
+    call_count = 0
+
+    def fail_then_cancel(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError()
+        raise Exception(f"Fail {call_count}")
+
+    mocker.patch("serialx.async_serial_for_url", side_effect=fail_then_cancel)
+    mocker.patch("asyncio.sleep", return_value=None)
+
+    # serial_task catches CancelledError internally and returns
+    await serial_task(context)
+
+    assert context.lasterror_serial is not None
+
+
+async def test_read_loop_header():
+    """Test _read_loop header handling."""
+    context = state_module.get_context()
+    mock_serial = AsyncMock()
+    # 1. Header
+    # 2. ID Packet (too short, will set error)
+    # 3. Empty string decoded
+    # 4. Empty bytes -> break
+    mock_serial.readline = AsyncMock(side_effect=[b"/HEADER:V1\r\n", b"ID:123\r\n", b"\r\n", b""])
 
     with patch("serial_handler.logger") as mock_logger:
-        serial_task_missing._read_loop(mock_serial)
+        await _read_loop(context, mock_serial)
 
         # Verify header parsed
-        assert serial_task_missing.app_context.s0pcm_firmware == "V1"
+        assert context.s0pcm_firmware == "V1"
         # Verify warning for empty packet
         assert mock_logger.warning.called
         assert "Empty Packet received" in mock_logger.warning.call_args[0][0]
 
 
-def test_run_exclusive_mode(mocker):
-    """Test that exclusive=True is passed to serial_for_url in run()."""
+async def test_serial_task_exclusive_mode(mocker):
+    """Test that exclusive=True is passed to async_serial_for_url."""
     context = state_module.get_context()
     context.config = make_test_config()
-
-    stopper = threading.Event()
-    task = TaskReadSerial(context, threading.Event(), stopper)
     context.recovery_event.set()
 
-    def side_effect(*args, **kwargs):
-        stopper.set()
-        return MagicMock()
+    mock_ser = AsyncMock()
+    mock_ser.__aenter__ = AsyncMock(return_value=mock_ser)
+    mock_ser.__aexit__ = AsyncMock(return_value=False)
 
-    mock_serial_for_url = mocker.patch("serialx.serial_for_url", side_effect=side_effect)
-    mocker.patch.object(task, "_read_loop")
+    async def cancel_read(ctx, ser):
+        raise asyncio.CancelledError()
 
-    task.run()
+    mock_async_serial = mocker.patch("serialx.async_serial_for_url", return_value=mock_ser)
+    mocker.patch("serial_handler._read_loop", side_effect=cancel_read)
 
-    mock_serial_for_url.assert_called_once()
-    _, kwargs = mock_serial_for_url.call_args
+    # serial_task catches CancelledError internally and returns
+    await serial_task(context)
+
+    mock_async_serial.assert_called_once()
+    _, kwargs = mock_async_serial.call_args
     assert kwargs["exclusive"] is True
 
 
-def test_log_available_ports_with_ports(serial_task_missing):
+def test_log_available_ports_with_ports():
     """Test _log_available_ports when ports are detected."""
     mock_port = MagicMock()
     mock_port.device = "/dev/ttyACM0"
@@ -337,102 +310,56 @@ def test_log_available_ports_with_ports(serial_task_missing):
         patch("serialx.list_serial_ports", return_value=[mock_port]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        serial_task_missing._log_available_ports()
+        _log_available_ports()
         assert any("/dev/ttyACM0" in str(c) for c in mock_logger.info.call_args_list)
 
 
-def test_log_available_ports_no_ports(serial_task_missing):
+def test_log_available_ports_no_ports():
     """Test _log_available_ports when no ports are detected."""
     with (
         patch("serialx.list_serial_ports", return_value=[]),
         patch("serial_handler.logger") as mock_logger,
     ):
-        serial_task_missing._log_available_ports()
+        _log_available_ports()
         assert mock_logger.warning.called
         assert "No serial ports detected" in mock_logger.warning.call_args[0][0]
 
 
-def test_log_available_ports_exception(serial_task_missing):
+def test_log_available_ports_exception():
     """Test _log_available_ports handles exceptions gracefully."""
     with (
         patch("serialx.list_serial_ports", side_effect=OSError("Permission denied")),
         patch("serial_handler.logger") as mock_logger,
     ):
-        serial_task_missing._log_available_ports()
+        _log_available_ports()
         assert mock_logger.debug.called
         assert "Unable to enumerate" in mock_logger.debug.call_args[0][0]
 
 
-def test_log_available_ports_called_on_first_failure(mocker):
+async def test_log_available_ports_called_on_first_failure(mocker):
     """Test that _log_available_ports is called only on the first connection failure."""
     context = state_module.get_context()
     context.config = make_test_config()
-
-    stopper = threading.Event()
-    task = TaskReadSerial(context, threading.Event(), stopper)
     context.recovery_event.set()
 
-    def side_effect(*args, **kwargs):
-        if task._state.serialerror == 2:
-            stopper.set()
-        raise Exception(f"Fail {task._state.serialerror}")
+    call_count = 0
 
-    mocker.patch("serialx.serial_for_url", side_effect=side_effect)
-    mocker.patch("time.sleep")
-    mock_log_ports = mocker.patch.object(task, "_log_available_ports")
+    def fail_then_cancel(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            raise asyncio.CancelledError()
+        raise Exception(f"Fail {call_count}")
 
-    task.run()
+    mocker.patch("serialx.async_serial_for_url", side_effect=fail_then_cancel)
+    mocker.patch("asyncio.sleep", return_value=None)
+    mock_log_ports = mocker.patch("serial_handler._log_available_ports")
+
+    # serial_task catches CancelledError internally and returns
+    await serial_task(context)
 
     # Should be called exactly once (on first failure, not second)
     mock_log_ports.assert_called_once()
-
-
-def test_run_context_manager_closes_port(mocker):
-    """Test that run() uses context manager for safe serial port cleanup."""
-    context = state_module.get_context()
-    context.config = make_test_config()
-
-    stopper = threading.Event()
-    task = TaskReadSerial(context, threading.Event(), stopper)
-    context.recovery_event.set()
-
-    mock_ser = MagicMock()
-    mocker.patch("serialx.serial_for_url", return_value=mock_ser)
-
-    def stop_logic(ser):
-        stopper.set()
-
-    mocker.patch.object(task, "_read_loop", side_effect=stop_logic)
-
-    task.run()
-
-    # Verify __exit__ was called (context manager close)
-    mock_ser.__exit__.assert_called_once()
-
-
-# --- From test_loops.py ---
-
-
-def test_task_read_serial_loop_execution(mocker):
-    """Integrate TaskReadSerial loop."""
-    context = state_module.get_context()
-    context.config = make_test_config()
-
-    stopper = threading.Event()
-    task = TaskReadSerial(context, threading.Event(), stopper)
-
-    # CRITICAL: Serial task waits for recovery event!
-    context.recovery_event.set()
-
-    mocker.patch("serialx.serial_for_url", return_value=MagicMock())
-
-    def stop_logic(ser):
-        stopper.set()
-
-    mocker.patch.object(task, "_read_loop", side_effect=stop_logic)
-
-    task.run()
-    assert stopper.is_set()
 
 
 if __name__ == "__main__":

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -362,5 +362,36 @@ async def test_log_available_ports_called_on_first_failure(mocker):
     mock_log_ports.assert_called_once()
 
 
+async def test_read_loop_cancelled_error():
+    """Test _read_loop raises CancelledError on cancellation."""
+    from serial_handler import _read_loop
+
+    context = state_module.get_context()
+    mock_serial = AsyncMock()
+    mock_serial.readline = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await _read_loop(context, mock_serial)
+
+
+async def test_serial_task_fatal_exception_outer(mocker):
+    """Test outer Exception block in serial_task."""
+    from serial_handler import serial_task
+
+    context = state_module.get_context()
+    context.config = make_test_config()
+
+    # Mock recovery_event.wait to raise an exception
+    mocker.patch.object(context.recovery_event, "wait", side_effect=ValueError("Fatal Wait Error"))
+    mocker.patch("serial_handler.logger.error")
+
+    await serial_task(context)
+
+    # Verify logger.error was called with fatal exception info
+    import serial_handler
+
+    serial_handler.logger.error.assert_called_with("Fatal exception in Serial Task", exc_info=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2,6 +2,7 @@
 Tests for state management (state.py).
 """
 
+import asyncio
 import datetime
 
 import pytest
@@ -50,38 +51,23 @@ def test_app_context_initialization():
     """Test AppContext initialization."""
     context = state_module.AppContext()
 
-    assert context.lock is not None
     assert context.recovery_event is not None
+    assert isinstance(context.recovery_event, asyncio.Event)
+    assert context.trigger_event is not None
+    assert isinstance(context.trigger_event, asyncio.Event)
     assert isinstance(context.state, state_module.AppState)
-    assert isinstance(context.state_share, state_module.AppState)
     assert context.lasterror_serial is None
     assert context.lasterror_mqtt is None
     assert context.s0pcm_firmware == "Unknown"
 
 
-def test_app_context_register_trigger():
-    """Test AppContext register_trigger method."""
-    import threading
-
-    context = state_module.AppContext()
-    trigger = threading.Event()
-
-    context.register_trigger(trigger)
-
-    assert context.trigger_event is trigger
-
-
 def test_app_context_set_error_with_trigger():
     """Test AppContext set_error triggers event."""
-    import threading
-
     context = state_module.AppContext()
-    trigger = threading.Event()
-    context.register_trigger(trigger)
 
     context.set_error("Test Error", category="serial")
 
-    assert trigger.is_set()
+    assert context.trigger_event.is_set()
     assert context.lasterror_serial == "Test Error"
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -83,7 +83,7 @@ def test_app_state_iter():
     state.meters[1] = state_module.MeterState(total=100)
 
     assert 1 in state.meters
-    assert "date" in state.model_fields
+    assert "date" in state_module.AppState.model_fields
 
 
 def test_meter_state_initial_values():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,22 +12,22 @@ import pytest
 import utils
 
 
-def test_get_version_from_env(mocker):
+async def test_get_version_from_env(mocker):
     """Test get_version from environment variable."""
     mocker.patch.dict(os.environ, {"S0PCM_READER_VERSION": "3.1.0"})
-    assert utils.get_version() == "3.1.0"
+    assert await utils.get_version() == "3.1.0"
 
 
-def test_get_version_fallback(mocker, tmp_path, monkeypatch):
+async def test_get_version_fallback(mocker, tmp_path, monkeypatch):
     """Test GetVersion fallback when env is missing and no config file."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
     # Mock __file__ to point to our tmp_path
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
+async def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
     """Test GetVersion reading from config.yaml."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -38,11 +38,11 @@ def test_get_version_config_yaml(mocker, tmp_path, monkeypatch):
     # Mock __file__ so utils looks in tmp_path
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
-    version = utils.get_version()
+    version = await utils.get_version()
     assert "3.0.0-test" in version
 
 
-def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
+async def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
     """Test get_version handles invalid YAML gracefully."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -53,10 +53,10 @@ def test_get_version_invalid_yaml(mocker, tmp_path, monkeypatch):
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
     # Should fall back to 'dev' because our file is invalid
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
+async def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
     """Test get_version when YAML exists but has no version key."""
     monkeypatch.chdir(tmp_path)
     mocker.patch.dict(os.environ, {}, clear=True)
@@ -66,16 +66,16 @@ def test_get_version_yaml_no_version_key(mocker, tmp_path, monkeypatch):
 
     mocker.patch("utils.__file__", str(tmp_path / "utils.py"))
 
-    assert utils.get_version() == "dev"
+    assert await utils.get_version() == "dev"
 
 
-def test_get_supervisor_config_no_token(mocker):
+async def test_get_supervisor_config_no_token(mocker):
     """Test GetSupervisorConfig when token is missing."""
     mocker.patch.dict(os.environ, {}, clear=True)
-    assert utils.get_supervisor_config("mqtt") == {}
+    assert await utils.get_supervisor_config("mqtt") == {}
 
 
-def test_get_supervisor_config_success(mocker):
+async def test_get_supervisor_config_success(mocker):
     """Test successful Supervisor API config fetch."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
 
@@ -89,21 +89,34 @@ def test_get_supervisor_config_success(mocker):
 
     mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-    result = utils.get_supervisor_config("mqtt")
+    result = await utils.get_supervisor_config("mqtt")
 
     assert result["host"] == "core-mosquitto"
     assert result["port"] == 1883
     assert result["username"] == "mqtt_user"
 
 
-def test_get_supervisor_config_api_error(mocker):
+async def test_get_supervisor_config_api_error(mocker):
     """Test Supervisor API handles errors gracefully."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     # Raise URLError which is one of the caught exceptions
     mocker.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("API Error"))
 
-    result = utils.get_supervisor_config("mqtt")
+    result = await utils.get_supervisor_config("mqtt")
 
+    assert result == {}
+
+
+async def test_get_supervisor_config_status_not_200(mocker):
+    """Test Supervisor API returns empty dict when response status is not 200."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mock_response = MagicMock()
+    mock_response.status = 204
+    mock_response.__enter__ = lambda self: self
+    mock_response.__exit__ = lambda self, *args: None
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    result = await utils.get_supervisor_config("mqtt")
     assert result == {}
 
 
@@ -112,13 +125,13 @@ def test_get_supervisor_config_api_error(mocker):
 # ------------------------------------------------------------------------------------
 
 
-def test_get_ha_core_version_no_token(mocker):
+async def test_get_ha_core_version_no_token(mocker):
     """Test get_ha_core_version when token is missing."""
     mocker.patch.dict(os.environ, {}, clear=True)
-    assert utils.get_ha_core_version() is None
+    assert await utils.get_ha_core_version() is None
 
 
-def test_get_ha_core_version_success(mocker):
+async def test_get_ha_core_version_success(mocker):
     """Test successful HA core version fetch."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     mock_response = MagicMock()
@@ -128,14 +141,26 @@ def test_get_ha_core_version_success(mocker):
     mock_response.__exit__ = lambda self, *args: None
     mocker.patch("urllib.request.urlopen", return_value=mock_response)
 
-    assert utils.get_ha_core_version() == "2025.5.0"
+    assert await utils.get_ha_core_version() == "2025.5.0"
 
 
-def test_get_ha_core_version_error(mocker):
+async def test_get_ha_core_version_error(mocker):
     """Test get_ha_core_version handles errors gracefully."""
     mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
     mocker.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("API Error"))
-    assert utils.get_ha_core_version() is None
+    assert await utils.get_ha_core_version() is None
+
+
+async def test_get_ha_core_version_status_not_200(mocker):
+    """Test get_ha_core_version returns None when response status is not 200."""
+    mocker.patch.dict(os.environ, {"SUPERVISOR_TOKEN": "test_token"})
+    mock_response = MagicMock()
+    mock_response.status = 204
+    mock_response.__enter__ = lambda self: self
+    mock_response.__exit__ = lambda self, *args: None
+    mocker.patch("urllib.request.urlopen", return_value=mock_response)
+
+    assert await utils.get_ha_core_version() is None
 
 
 def test_parse_ha_version():

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -1,7 +1,7 @@
 configuration:
   device:
     name: "Serial Port"
-    description: "The serial port device where your S0PCM is connected (Default: /dev/ttyACM0)."
+    description: "Optional. The serial port device where your S0PCM is connected (Default: auto-detect). Enable 'Show unused optional configuration options' to manually select a port."
   mqtt:
     name: "Basic MQTT Settings"
     description: "Leave these fields empty if you use Home Assistant OS with the Mosquitto broker App! We will automatically connect."

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b4"
+version = "5.0.0b5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-10T18:16:44.278675161Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.3.4b21"
+version = "4.4.0b0"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-13T08:31:27.822077864Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b8"
+version = "5.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-11T09:37:23.719466306Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b0"
+version = "5.0.0b1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ requires-dist = [
     { name = "aiomqtt", specifier = ">=2.5.1" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "serialx", specifier = "==1.8.1" },
+    { name = "serialx", specifier = "==1.8.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -347,20 +347,20 @@ test = [
 
 [[package]]
 name = "serialx"
-version = "1.8.1"
+version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/c7/1fad1ffa6522334628a22710a23b31a393d28a26bd3ab60ad53da1f9eab8/serialx-1.8.1.tar.gz", hash = "sha256:ab0ff3c65b41eb08ea2400bec424e8882eaf0f31c56c4f6930d19f9ffe8e6ea6", size = 694974, upload-time = "2026-06-09T20:33:47.579Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/80/778c6da23924b718c282024bcde331cf8e417ec1274d2f198f65cff7503a/serialx-1.8.2.tar.gz", hash = "sha256:90c912ec8ceb4ae26a7dca158ca21e5bd8d73ddfc93c5e8d8b101a22ddccbb9a", size = 695526, upload-time = "2026-06-12T16:06:57.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/b0/2d1b152ac121ffe614c20d85cb52cdda64f952d55c55a0cb3b188b820be4/serialx-1.8.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d978cceb620740d7f40191c3a62733b54115a848ff8cc97232e153cea2188ec4", size = 285351, upload-time = "2026-06-09T20:33:39.503Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/6a/c862e046829f4670131f6111baeae96bfed2db3ebaaa3fc8f9313513fbd1/serialx-1.8.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07e3caea63f12658e1c884a307c5a14e51360f614525f1153c5fcfe22dd225af", size = 282907, upload-time = "2026-06-09T20:33:41.103Z" },
-    { url = "https://files.pythonhosted.org/packages/74/35/115f7b3c7ca3b62e557c1265db73da13034fbdfac2dfbb17c5e5aa436cab/serialx-1.8.1-cp310-abi3-win32.whl", hash = "sha256:63f45f2f87df5c89774fa166c101993b0e043c25d22c5f95b3bfc82a1cc44527", size = 184451, upload-time = "2026-06-09T20:33:42.372Z" },
-    { url = "https://files.pythonhosted.org/packages/86/5d/a892139a4e1245b90ab221c36466666841eec63dfecdbece26593948497b/serialx-1.8.1-cp310-abi3-win_amd64.whl", hash = "sha256:923b8c69806865466ad587779b64d79831876d7f8af7e0b6079d37d21da40008", size = 190236, upload-time = "2026-06-09T20:33:43.695Z" },
-    { url = "https://files.pythonhosted.org/packages/29/17/72c081b17ecd1b3b8d7688ea301784caa6cf2edeaf02cd4d6a17bbdc3450/serialx-1.8.1-cp310-abi3-win_arm64.whl", hash = "sha256:ad07d7eb4e3034399dbf4e3e975b050d950e9c57011820ed66f4c833f10fda70", size = 186502, upload-time = "2026-06-09T20:33:45.06Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/82/dd17aa90d43ce6c608720e5ab7a80543323829ca50fae6b6d2ff190f5fa1/serialx-1.8.1-py3-none-any.whl", hash = "sha256:1f46c01c012fb6b513e1f40449bc5d71c5980865fc01e3eb457a2164671cf189", size = 66721, upload-time = "2026-06-09T20:33:46.301Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/b4c05bfbe7021874f4f8b007d0057bf50e92854d63bb1dab07fd3677e376/serialx-1.8.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d2904605e59357b9815aaa70828f28429767821638fceef228f32b8fca9ffb5c", size = 285301, upload-time = "2026-06-12T16:06:48.23Z" },
+    { url = "https://files.pythonhosted.org/packages/38/32/e6998be005770fbefd71bd3b9e095eb3a4fc055649967dcf82a6747fb6dc/serialx-1.8.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:abaee5c042194eaf95466e8e5eec6920af2eb0dbc00b91f1d765a0602bfd0d23", size = 282856, upload-time = "2026-06-12T16:06:49.91Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d5/598fc77e904c584e4420cc4be7878292f595f40e6f32092649d7cd580f28/serialx-1.8.2-cp310-abi3-win32.whl", hash = "sha256:42cd054add10e390856608a6b0abb3bdf1b8aa078f26f60d7fcd852603f91417", size = 183863, upload-time = "2026-06-12T16:06:51.191Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1d/8dfbd66cdf4129d991574c4ebcd502636b178e408a41cdf8ebc04353cab5/serialx-1.8.2-cp310-abi3-win_amd64.whl", hash = "sha256:3e098c502639c7b220c419634101f28b9878a82fcee0cf06e074abb3e97f2c3e", size = 189886, upload-time = "2026-06-12T16:06:52.792Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b9/138584b89a109f4e4ce82176380b44a748808033d55c9cbb1b39de0f52eb/serialx-1.8.2-cp310-abi3-win_arm64.whl", hash = "sha256:36f82e21c9b0215beae4c983d221071a44ecdcf2f7a98c659af596ff7adbaa65", size = 186459, upload-time = "2026-06-12T16:06:54.283Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/90/9cd83042a221756e41ed8c018344e8833788c16e9bac144dab3292f9fa3c/serialx-1.8.2-py3-none-any.whl", hash = "sha256:6e6cffc1caec242fb06d8e16dd7880c8ba53c366ee2c43045fc38e8935ac8a6d", size = 66674, upload-time = "2026-06-12T16:06:55.724Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b1"
+version = "5.0.0b2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b5"
+version = "5.0.0b6"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,20 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-11T09:37:23.719466306Z"
 exclude-newer-span = "P3D"
+
+[[package]]
+name = "aiomqtt"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "paho-mqtt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/44/cfc58272783a11729462dc6df5adbfeabd084f840f609054ac772ae98c19/aiomqtt-2.5.1.tar.gz", hash = "sha256:25a0a47d157e8f158d2da1110ea4786c0615518751e94f7b04976c977a8ff20d", size = 86641, upload-time = "2026-03-05T18:28:56.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/9e/5089fa596220bf0dc73deeb23db27904e4b3504986caf08571f6f5cb84a8/aiomqtt-2.5.1-py3-none-any.whl", hash = "sha256:fd58c3593160e4d475d90ce911cdfc4239cd64de96b0ba22edf6c86bd7afa278", size = 16051, upload-time = "2026-03-05T18:28:55.14Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -181,6 +193,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -284,10 +308,10 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.4.0b1"
+version = "5.0.0b0"
 source = { virtual = "." }
 dependencies = [
-    { name = "paho-mqtt" },
+    { name = "aiomqtt" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "serialx" },
@@ -296,6 +320,7 @@ dependencies = [
 [package.dev-dependencies]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
@@ -304,7 +329,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "paho-mqtt", specifier = "==2.1.0" },
+    { name = "aiomqtt", specifier = ">=2.5.1" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "serialx", specifier = "==1.8.1" },
@@ -313,6 +338,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 test = [
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b6"
+version = "5.0.0b7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b7"
+version = "5.0.0b8"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b3"
+version = "5.0.0b4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.0b2"
+version = "5.0.0b3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-10T18:16:44.278675161Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "4.4.0b0"
+version = "4.4.0b1"
 source = { virtual = "." }
 dependencies = [
     { name = "paho-mqtt" },


### PR DESCRIPTION
Automated stable release PR for version 5.0.0.

### Changes in this release:
- Merge pull request #304 from darkrain-nl/renovate/serialx-1.x
- chore(deps): update python:3.14-alpine docker digest to 003970a (#300)
- chore(deps): update ghcr.io/astral-sh/uv docker digest to ff07b86 (#299)

### Changelog entries:
```markdown
### Added
- **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.
- **USB Port Auto-Detection**: Enumerate and automatically select S0PCM serial ports (CH340 chipset/Vendor ID `0x1a86`) when no device path is manually specified, falling back to any USB serial or standard interface. Made the `device` configuration parameter optional in the Home Assistant configuration schema to allow leaving it empty for auto-detection.
- **Improved Reconnection & Error State Syncing**: Added resilient MQTT reconnection logic using `asyncio.TaskGroup`. The connection error state is now safely retained upon connection failure and published to the MQTT broker immediately upon successful reconnection, prior to clearing it via a delayed timer.

### Fixed
- **USB Auto-Detection Schema**: Removed `device: null` default option to prevent voluptuous schema validation errors when saving configuration with an unselected serial port.
- **Add-on Hardware Access**: Added `uart: true` permission flag to container configuration to allow scanning and mapping host USB serial interfaces inside the container.

### Security
- **Integer Overflow Guard**: Added 32-bit signed integer clamping to meter `total` and `today` accumulators, preventing corrupt serial data from exceeding the HA number entity maximum (2,147,483,647).
- **MQTT Topic Sanitization**: Strengthened meter name sanitization by filtering non-printable characters (control chars, null bytes) in both MQTT command handling and discovery topic construction, preventing log injection and topic corruption.
- **Healthcheck Hardening**: Tightened Docker HEALTHCHECK process detection to require both a Python interpreter and the script name in the cmdline, preventing false positives from non-Python processes.

### Changed
- **Serial Timeout**: Changed default serial read timeout from infinite (`None`) to 30 seconds, ensuring the serial thread can detect hardware hangs and respond to shutdown signals.
- **CI/CD**: Fixed `git config --global` scope in the `sync-to-beta-repo` CI job to use local repository scope for consistency and OpenSSF best practices.
- **Dependencies**: Replaced `paho-mqtt` dependency with `aiomqtt` and updated other dependencies (including `serialx` to 1.8.2).
```
