### PR TITLE
chore: update Renovate configuration for build.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
                 "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "docker",
+            "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-alpine(?<patch>\\d+)\\.(?<build>\\d+)$",
             "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
         }
     ],


### PR DESCRIPTION
Updates renovate.json to use custom regex versioning for build.yaml base images.