### PR TITLE
chore: simplify Renovate custom manager pattern and remove autoReplaceStringTemplate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,11 +40,10 @@
                 "/(^|/)build\\.yaml$/"
             ],
             "matchStrings": [
-                "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+                "(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "regex:^(?<compatibility>\\d+\\.\\d+-alpine)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
-            "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+            "versioningTemplate": "regex:^(?<compatibility>\\d+\\.\\d+-alpine)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
Simplifies the custom regex manager matching pattern and removes autoReplaceStringTemplate so Renovate can cleanly perform inline replacement of version tags in build.yaml, preventing update failures.