### PR TITLE
Release v5.0.1-b5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Memory Optimization**: Integrated `jemalloc` as a custom memory allocator in the Home Assistant addon container to reduce memory fragmentation and footprint over long runtimes.
 
+### Changed
+- **Dependencies**: Bumped Home Assistant base images to `3.14-alpine3.24` (Alpine 3.24) in `build.yaml`.
+
 ## [5.0.0] - 2026-06-16
 ### Added
 - **Asyncio Architecture**: Complete rewrite of the application core to run on a single-threaded `asyncio` event loop. Replaced `paho-mqtt` with `aiomqtt` and ported the serial read loop to use non-blocking `serialx.AsyncSerial`. This eliminates background threads and locking primitives (`threading.Lock`), resolving potential race conditions and improving system resource utilization. This transition dramatically reduces CPU overhead and memory footprint, making internal state updates **~90x more efficient** in benchmarks.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 image: ghcr.io/darkrain-nl/addon-s0pcm_reader
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.14-alpine3.23
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.23
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.14-alpine3.24
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.24
 labels:
   io.hass.type: addon
   org.opencontainers.image.title: "S0PCM Reader"

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
                 "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-alpine(?<patch>\\d+)\\.(?<build>\\d+)$",
+            "versioningTemplate": "regex:^(?<compatibility>\\d+\\.\\d+-alpine)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
             "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
         }
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
                 "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "docker",
+            "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-alpine(?<patch>\\d+)\\.(?<build>\\d+)$",
             "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
         }
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -40,11 +40,10 @@
                 "/(^|/)build\\.yaml$/"
             ],
             "matchStrings": [
-                "(?<arch>aarch64|amd64):\\s+(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+                "(?<depName>ghcr\\.io/home-assistant/[^:]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
             ],
             "datasourceTemplate": "docker",
-            "versioningTemplate": "regex:^(?<compatibility>\\d+\\.\\d+-alpine)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$",
-            "autoReplaceStringTemplate": "{{{arch}}}: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+            "versioningTemplate": "regex:^(?<compatibility>\\d+\\.\\d+-alpine)(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?$"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.1-b5.

### Changes in this release:
- Merge pull request #313 from darkrain-nl/renovate/home-assistant-base-images

### Changelog entries:
```markdown
### Added
- **Memory Optimization**: Integrated `jemalloc` as a custom memory allocator in the Home Assistant addon container to reduce memory fragmentation and footprint over long runtimes.

### Changed
- **Dependencies**: Bumped Home Assistant base images to `3.14-alpine3.24` (Alpine 3.24) in `build.yaml`.
```
