### PR TITLE
Release v5.0.2-b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2-b0] - 2026-06-20
+### Fixed
+- **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.
+
 ## [5.0.1] - 2026-06-20
 ### Added
 - **Memory Optimization**: Integrated `jemalloc` as a custom memory allocator in the Home Assistant addon container to reduce memory fragmentation and footprint over long runtimes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Default to scratch to suppress 'InvalidDefaultArgInFrom' warnings.
+# Default to amd64-base-python to satisfy OpenSSF Scorecard Pinned-Dependencies check.
 # The true base image is always injected by builder using build.yaml.
-ARG BUILD_FROM="scratch"
+ARG BUILD_FROM="ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.24@sha256:f59ecbbc63f781bf1215dd6b70f890a0487ff434ffc0fa721b368a5f4613d176"
 FROM ${BUILD_FROM}
 
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 image: ghcr.io/darkrain-nl/addon-s0pcm_reader
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.14-alpine3.24
-  amd64: ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.24
+  aarch64: ghcr.io/home-assistant/aarch64-base-python:3.14-alpine3.24@sha256:6ea2adb735fd7121e43ef9f5401caac06266b9a73afecebaf600d21d7b5b23bc
+  amd64: ghcr.io/home-assistant/amd64-base-python:3.14-alpine3.24@sha256:f59ecbbc63f781bf1215dd6b70f890a0487ff434ffc0fa721b368a5f4613d176
 labels:
   io.hass.type: addon
   org.opencontainers.image.title: "S0PCM Reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.1"
+version: "5.0.2-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.1"
+version = "5.0.2-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
                 "ghcr.io/home-assistant/**"
             ],
             "groupName": "Home Assistant Base Images",
-            "pinDigests": false
+            "pinDigests": true
         },
         {
             "description": "Automerge Docker digest updates weekly to prevent perpetual force-push cycles",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-17T13:54:10.432833909Z"
+exclude-newer = "2026-06-17T14:15:41.806300109Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.1"
+version = "5.0.2b0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.2-b0.

### Changes in this release:

### Changelog entries:
```markdown
### Fixed
- **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.
```
