### PR TITLE
Release v5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.2-b1] - 2026-06-20
+## [5.0.2] - 2026-06-20
 ### Fixed
 - **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.2-b1"
+version: "5.0.2"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.2-b1"
+version = "5.0.2"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-17T14:26:30.615881642Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.2b1"
+version = "5.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.2.

### Changes in this release:

### Changelog entries:
```markdown
### Fixed
- **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.
```
