### PR TITLE
Release v5.0.3-b0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish
 
 on:
   workflow_call:
+    secrets:
+      BETA_SYNC_TOKEN:
+        required: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -24,6 +27,7 @@ jobs:
           sparse-checkout: |
             config.yaml
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Check if version exists as tag
         id: check
@@ -62,6 +66,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Checkout code
+        # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
@@ -191,14 +196,17 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Get version and build_from
         id: version
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           VERSION=$(grep '^version:' config.yaml | sed 's/version: *"\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           
-          BUILD_FROM=$(grep "^  ${{ matrix.arch }}:" build.yaml | awk '{print $2}' | tr -d '"')
+          BUILD_FROM=$(grep "^  ${ARCH}:" build.yaml | awk '{print $2}' | tr -d '"')
           echo "build_from=$BUILD_FROM" >> "$GITHUB_OUTPUT"
 
       - name: Build image
@@ -228,6 +236,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Get version
         id: version
@@ -258,6 +267,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -304,6 +314,7 @@ jobs:
           ref: ${{ github.ref_name }}
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Read version from config.yaml
         id: version
@@ -315,10 +326,12 @@ jobs:
 
       - name: Check if tag exists
         id: check_tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git ls-remote --tags origin "${{ steps.version.outputs.tag }}" | grep -q .; then
+          if git ls-remote --tags origin "${TAG}" | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag ${{ steps.version.outputs.tag }} already exists, skipping release"
+            echo "Tag ${TAG} already exists, skipping release"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
@@ -326,14 +339,18 @@ jobs:
       - name: Extract Release Notes from CHANGELOG
         if: steps.check_tag.outputs.exists == 'false'
         id: extract_notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          IS_BETA: ${{ needs.check.outputs.is_beta }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           # Extract the section from CHANGELOG.md for the current version
-          awk '/^## \[${{ steps.version.outputs.version }}\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > release_notes.md
+          awk -v ver="${VERSION}" '$0 ~ "^## \\[" ver "\\]"{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > release_notes.md
           
           # Manually generate "What's Changed" to avoid GitHub's flawed detection
           # Beta: Compare against the absolute last tag
           # Stable: Compare against the last STABLE tag (exclude beta tags)
-          if [ "${{ needs.check.outputs.is_beta }}" = "true" ]; then
+          if [ "${IS_BETA}" = "true" ]; then
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           else
             PREV_TAG=$(git describe --tags --abbrev=0 --exclude "*-b*" HEAD^ 2>/dev/null || echo "")
@@ -349,10 +366,11 @@ jobs:
               echo "Internal maintenance and direct commits." >> release_notes.md
             fi
             
-            echo -e "\n**Full Changelog**: https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader/compare/$PREV_TAG...${{ steps.version.outputs.tag }}" >> release_notes.md
+            echo -e "\n**Full Changelog**: https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader/compare/$PREV_TAG...${TAG}" >> release_notes.md
           fi
 
       - name: Create Stable Release
+        # zizmor: ignore[superfluous-actions]
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'false'
@@ -367,6 +385,7 @@ jobs:
           prerelease: false
 
       - name: Create Beta Pre-release
+        # zizmor: ignore[superfluous-actions]
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'true'
@@ -388,6 +407,7 @@ jobs:
     if: github.ref_name == 'beta' && needs.prepare.outputs.did_bump == 'true'
     steps:
       - name: Checkout code
+        # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       is_beta: ${{ steps.check.outputs.is_beta }}
     steps:
       - name: Checkout config.yaml
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           sparse-checkout: |
             config.yaml
@@ -62,7 +62,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -188,7 +188,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -225,7 +225,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -255,7 +255,7 @@ jobs:
     if: needs.check.outputs.should_build == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -299,7 +299,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
           fetch-tags: true
@@ -388,7 +388,7 @@ jobs:
     if: github.ref_name == 'beta' && needs.prepare.outputs.did_bump == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: dev
           token: ${{ secrets.BETA_SYNC_TOKEN }}
@@ -410,7 +410,7 @@ jobs:
     if: github.ref_name == 'beta' || github.ref_name == 'main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
           path: main-repo

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -103,7 +103,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Build Standalone Stack
         run: docker compose -f tests/standalone/docker-compose.yml build
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Check version consistency
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -76,6 +78,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -104,6 +108,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Build Standalone Stack
         run: docker compose -f tests/standalone/docker-compose.yml build
@@ -140,6 +146,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check version consistency
         run: |
@@ -181,4 +189,5 @@ jobs:
       packages: write
       id-token: write
     uses: ./.github/workflows/publish.yml
-    secrets: inherit
+    secrets:
+      BETA_SYNC_TOKEN: ${{ secrets.BETA_SYNC_TOKEN }}

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Update copyright year in LICENSE
         run: |

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Update copyright year in LICENSE
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, beta, develop, dev]
+  pull_request:
+    branches: [main, beta, develop, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor Static Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.3] - [Unreleased]
+### Added
+- **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
+
+### Changed
+- **CI/CD**: Hardened all GitHub Actions workflows against template injection, credential persistence, and excessive secret access.
+- **Dependencies**: Dependency updates.
+
 ## [5.0.2] - 2026-06-20
 ### Fixed
 - **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3] - [Unreleased]
+## [5.0.3-b0] - [Unreleased]
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.2"
+version: "5.0.3-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.2"
+version = "5.0.3-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/release.sh
+++ b/release.sh
@@ -64,7 +64,7 @@ fi
 echo -e "${GREEN}PR Ready: $BETA_PR_URL${NC}"
 
 echo -e "${YELLOW}Merging PR into 'beta'...${NC}"
-gh pr merge "$BETA_PR_URL" --merge
+gh pr merge "$BETA_PR_URL" --squash
 
 # 5. Sync Local Beta
 echo -e "${YELLOW}Switching to 'beta' and pulling latest changes...${NC}"
@@ -122,7 +122,7 @@ if [ "$IS_BETA" = false ]; then
     echo -e "${GREEN}PR Ready: $PR_URL${NC}"
 
     echo -e "${YELLOW}Merging PR into 'main'...${NC}"
-    gh pr merge "$PR_URL" --merge
+    gh pr merge "$PR_URL" --squash
 
     echo -e "${YELLOW}Switching to 'main' and pulling...${NC}"
     git checkout main

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -15,7 +15,7 @@ WORKDIR /workspace
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 # Install all deps (prod + test group)
 COPY pyproject.toml uv.lock ./

--- a/tests/docker-test.sh
+++ b/tests/docker-test.sh
@@ -28,6 +28,9 @@ if [ "$1" == "lint" ]; then
     echo -e "${YELLOW}Running Ruff Format...${NC}"
     docker exec "$CONTAINER_ID" ruff format .
 
+    echo -e "${YELLOW}Running Zizmor workflow audit...${NC}"
+    uvx zizmor --offline .
+
     echo -e "${GREEN}Copying patched files back to host...${NC}"
     docker cp "${CONTAINER_ID}:/workspace/rootfs" .
     docker cp "${CONTAINER_ID}:/workspace/tests" .

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -4,7 +4,7 @@ WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --system --no-cache -r - && \

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 # Use the project's lock file for paho-mqtt version consistency
 COPY pyproject.toml uv.lock ./

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-17T14:26:30.615881642Z"
+exclude-newer = "2026-06-21T11:19:36.301695302Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.2"
+version = "5.0.3b0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Automated merge of dev into beta for release v5.0.3-b0.

### Changes in this release:
- chore(deps): update actions/checkout action to v7 (#322)
- chore(deps): update ghcr.io/astral-sh/uv docker digest to d0a0a75 (#320)

### Changelog entries:
```markdown
### Added
- **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.

### Changed
- **CI/CD**: Hardened all GitHub Actions workflows against template injection, credential persistence, and excessive secret access.
- **Dependencies**: Dependency updates.
```
