### PR TITLE
Release v5.0.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -410,7 +410,6 @@ jobs:
         # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: dev
           token: ${{ secrets.BETA_SYNC_TOKEN }}
           fetch-depth: 0
 
@@ -418,9 +417,17 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          # Fetch all branches to ensure origin/beta is available
-          git fetch origin beta
-          git merge origin/beta --no-ff -m "ci: sync beta back to dev"
+          
+          # Fetch origin dev, and create/checkout it locally
+          if git fetch origin dev; then
+            git checkout dev
+            git fetch origin beta
+            git merge origin/beta --no-ff -m "ci: sync beta back to dev"
+          else
+            echo "dev branch not found on origin. Recreating dev branch from current HEAD..."
+            git checkout -b dev
+          fi
+          
           git push origin dev
 
   sync-to-beta-repo:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish
 
 on:
   workflow_call:
+    secrets:
+      BETA_SYNC_TOKEN:
+        required: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -19,11 +22,12 @@ jobs:
       is_beta: ${{ steps.check.outputs.is_beta }}
     steps:
       - name: Checkout config.yaml
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           sparse-checkout: |
             config.yaml
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Check if version exists as tag
         id: check
@@ -62,7 +66,8 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -188,17 +193,20 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Get version and build_from
         id: version
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           VERSION=$(grep '^version:' config.yaml | sed 's/version: *"\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           
-          BUILD_FROM=$(grep "^  ${{ matrix.arch }}:" build.yaml | awk '{print $2}' | tr -d '"')
+          BUILD_FROM=$(grep "^  ${ARCH}:" build.yaml | awk '{print $2}' | tr -d '"')
           echo "build_from=$BUILD_FROM" >> "$GITHUB_OUTPUT"
 
       - name: Build image
@@ -225,9 +233,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Get version
         id: version
@@ -255,9 +264,10 @@ jobs:
     if: needs.check.outputs.should_build == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -299,11 +309,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Read version from config.yaml
         id: version
@@ -315,10 +326,12 @@ jobs:
 
       - name: Check if tag exists
         id: check_tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git ls-remote --tags origin "${{ steps.version.outputs.tag }}" | grep -q .; then
+          if git ls-remote --tags origin "${TAG}" | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag ${{ steps.version.outputs.tag }} already exists, skipping release"
+            echo "Tag ${TAG} already exists, skipping release"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
@@ -326,14 +339,18 @@ jobs:
       - name: Extract Release Notes from CHANGELOG
         if: steps.check_tag.outputs.exists == 'false'
         id: extract_notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          IS_BETA: ${{ needs.check.outputs.is_beta }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           # Extract the section from CHANGELOG.md for the current version
-          awk '/^## \[${{ steps.version.outputs.version }}\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > release_notes.md
+          awk -v ver="${VERSION}" '$0 ~ "^## \\[" ver "\\]"{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' > release_notes.md
           
           # Manually generate "What's Changed" to avoid GitHub's flawed detection
           # Beta: Compare against the absolute last tag
           # Stable: Compare against the last STABLE tag (exclude beta tags)
-          if [ "${{ needs.check.outputs.is_beta }}" = "true" ]; then
+          if [ "${IS_BETA}" = "true" ]; then
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           else
             PREV_TAG=$(git describe --tags --abbrev=0 --exclude "*-b*" HEAD^ 2>/dev/null || echo "")
@@ -349,10 +366,11 @@ jobs:
               echo "Internal maintenance and direct commits." >> release_notes.md
             fi
             
-            echo -e "\n**Full Changelog**: https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader/compare/$PREV_TAG...${{ steps.version.outputs.tag }}" >> release_notes.md
+            echo -e "\n**Full Changelog**: https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader/compare/$PREV_TAG...${TAG}" >> release_notes.md
           fi
 
       - name: Create Stable Release
+        # zizmor: ignore[superfluous-actions]
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'false'
@@ -367,6 +385,7 @@ jobs:
           prerelease: false
 
       - name: Create Beta Pre-release
+        # zizmor: ignore[superfluous-actions]
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'true'
@@ -388,7 +407,8 @@ jobs:
     if: github.ref_name == 'beta' && needs.prepare.outputs.did_bump == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: dev
           token: ${{ secrets.BETA_SYNC_TOKEN }}
@@ -410,7 +430,7 @@ jobs:
     if: github.ref_name == 'beta' || github.ref_name == 'main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.ref_name }}
           path: main-repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Get build matrix
         id: matrix
-        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # master
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           architectures: '["amd64", "aarch64"]'
           image-name: addon-s0pcm_reader
@@ -210,7 +210,7 @@ jobs:
           echo "build_from=$BUILD_FROM" >> "$GITHUB_OUTPUT"
 
       - name: Build image
-        uses: home-assistant/builder/actions/build-image@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # master
+        uses: home-assistant/builder/actions/build-image@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           arch: ${{ matrix.arch }}
           build-args: |
@@ -245,7 +245,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Publish multi-arch manifest
-        uses: home-assistant/builder/actions/publish-multi-arch-manifest@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # master
+        uses: home-assistant/builder/actions/publish-multi-arch-manifest@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           architectures: '["amd64", "aarch64"]'
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -374,7 +374,7 @@ jobs:
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'false'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: ${{ github.ref_name }}
@@ -389,7 +389,7 @@ jobs:
         if: >
           steps.check_tag.outputs.exists == 'false' &&
           needs.check.outputs.is_beta == 'true'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: ${{ github.ref_name }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -75,7 +77,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -103,7 +107,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Build Standalone Stack
         run: docker compose -f tests/standalone/docker-compose.yml build
@@ -139,7 +145,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check version consistency
         run: |
@@ -181,4 +189,5 @@ jobs:
       packages: write
       id-token: write
     uses: ./.github/workflows/publish.yml
-    secrets: inherit
+    secrets:
+      BETA_SYNC_TOKEN: ${{ secrets.BETA_SYNC_TOKEN }}

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Update copyright year in LICENSE
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, beta, develop, dev]
+  pull_request:
+    branches: [main, beta, develop, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor Static Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b4] - 2026-06-24
+## [5.0.3-b5] - 2026-06-25
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b0] - [Unreleased]
+## [5.0.3-b1] - 2026-06-24
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b2] - 2026-06-24
+## [5.0.3-b3] - 2026-06-24
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b5] - 2026-06-25
+## [5.0.3] - 2026-06-25
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b1] - 2026-06-24
+## [5.0.3-b2] - 2026-06-24
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.3-b0] - [Unreleased]
+### Added
+- **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
+
+### Changed
+- **CI/CD**: Hardened all GitHub Actions workflows against template injection, credential persistence, and excessive secret access.
+- **Dependencies**: Dependency updates.
+
 ## [5.0.2] - 2026-06-20
 ### Fixed
 - **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: Hardened all GitHub Actions workflows against template injection, credential persistence, and excessive secret access.
 - **Dependencies**: Dependency updates.
 
+### Fixed
+- **Serial Connection**: Fixed an issue where only the first pulse counter (counter 1) reset/rolled over at 00:00. Now, all pulse counters correctly reset to 0 and roll over to yesterday's counts when the day changes (closes #327).
+
 ## [5.0.2] - 2026-06-20
 ### Fixed
 - **CI/CD**: Pinned all base image digests in `build.yaml` and the `Dockerfile` to satisfy OpenSSF Scorecard `Pinned-Dependencies` requirements and automated digest updates in Renovate configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.3-b3] - 2026-06-24
+## [5.0.3-b4] - 2026-06-24
 ### Added
 - **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b4"
+version: "5.0.3-b5"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b3"
+version: "5.0.3-b4"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.2"
+version: "5.0.3-b0"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b0"
+version: "5.0.3-b1"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b5"
+version: "5.0.3"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b2"
+version: "5.0.3-b3"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "S0PCM Reader"
 description: "S0PCM reader for Home Assistant"
-version: "5.0.3-b1"
+version: "5.0.3-b2"
 slug: "s0pcm_reader"
 image: "ghcr.io/darkrain-nl/addon-s0pcm_reader"
 url: "https://github.com/darkrain-nl/home-assistant-addon-s0pcm-reader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.2"
+version = "5.0.3-b0"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b3"
+version = "5.0.3-b4"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b0"
+version = "5.0.3-b1"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b4"
+version = "5.0.3-b5"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b5"
+version = "5.0.3"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b1"
+version = "5.0.3-b2"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s0pcm-reader"
-version = "5.0.3-b2"
+version = "5.0.3-b3"
 description = "S0PCM Reader Home Assistant App"
 requires-python = ">=3.14"
 dependencies = [

--- a/release.sh
+++ b/release.sh
@@ -64,7 +64,7 @@ fi
 echo -e "${GREEN}PR Ready: $BETA_PR_URL${NC}"
 
 echo -e "${YELLOW}Merging PR into 'beta'...${NC}"
-gh pr merge "$BETA_PR_URL" --merge
+gh pr merge "$BETA_PR_URL" --squash
 
 # 5. Sync Local Beta
 echo -e "${YELLOW}Switching to 'beta' and pulling latest changes...${NC}"
@@ -122,7 +122,7 @@ if [ "$IS_BETA" = false ]; then
     echo -e "${GREEN}PR Ready: $PR_URL${NC}"
 
     echo -e "${YELLOW}Merging PR into 'main'...${NC}"
-    gh pr merge "$PR_URL" --merge
+    gh pr merge "$PR_URL" --squash
 
     echo -e "${YELLOW}Switching to 'main' and pulling...${NC}"
     git checkout main

--- a/rootfs/usr/src/serial_handler.py
+++ b/rootfs/usr/src/serial_handler.py
@@ -81,11 +81,10 @@ def _update_meter(
     # Handle day-rollover
     today = datetime.date.today()
     if context.state.date != today:
-        logger.debug(f"Day changed from '{context.state.date}' to '{today}', rolling over counter '{meter_id}'.")
-        meter.yesterday = meter.today
-        meter.today = 0
-        # Note: context.state.date update should ideally happen once.
-        # We'll update it here so subsequent meters in the same packet also see the change.
+        logger.info(f"Day changed from '{context.state.date}' to '{today}', rolling over all counters.")
+        for _, m in context.state.meters.items():
+            m.yesterday = m.today
+            m.today = 0
         context.state.date = today
 
     # Check delta and update

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -15,7 +15,7 @@ WORKDIR /workspace
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 # Install all deps (prod + test group)
 COPY pyproject.toml uv.lock ./

--- a/tests/docker-test.sh
+++ b/tests/docker-test.sh
@@ -28,6 +28,9 @@ if [ "$1" == "lint" ]; then
     echo -e "${YELLOW}Running Ruff Format...${NC}"
     docker exec "$CONTAINER_ID" ruff format .
 
+    echo -e "${YELLOW}Running Zizmor workflow audit...${NC}"
+    uvx zizmor --offline .
+
     echo -e "${GREEN}Copying patched files back to host...${NC}"
     docker cp "${CONTAINER_ID}:/workspace/rootfs" .
     docker cp "${CONTAINER_ID}:/workspace/tests" .

--- a/tests/standalone/Dockerfile.test_app
+++ b/tests/standalone/Dockerfile.test_app
@@ -4,7 +4,7 @@ WORKDIR /
 COPY pyproject.toml uv.lock /tmp/uv/
 COPY rootfs /
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/uv && uv export --frozen --no-dev --no-emit-project --no-hashes | \
     uv pip install --system --no-cache -r - && \

--- a/tests/standalone/verifier/Dockerfile
+++ b/tests/standalone/verifier/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install uv
 # 0.11.2
-COPY --from=ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /uvx /bin/
 
 # Use the project's lock file for paho-mqtt version consistency
 COPY pyproject.toml uv.lock ./

--- a/tests/test_serial_handler.py
+++ b/tests/test_serial_handler.py
@@ -153,6 +153,23 @@ class TestDayChange:
         assert context.state.meters[1].today == 10
         assert context.state.date == datetime.date.today()
 
+    async def test_day_change_resets_multiple_meters(self):
+        context = state_module.get_context()
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+        # Set date in state
+        context.state.date = yesterday
+        context.state.meters[1] = state_module.MeterState(pulsecount=100, total=1000, today=50)
+        context.state.meters[2] = state_module.MeterState(pulsecount=200, total=2000, today=70)
+
+        _update_meter(context, 1, 110, 10, 10)
+        _update_meter(context, 2, 215, 15, 10)
+
+        assert context.state.meters[1].yesterday == 50
+        assert context.state.meters[1].today == 10
+        assert context.state.meters[2].yesterday == 70
+        assert context.state.meters[2].today == 15
+        assert context.state.date == datetime.date.today()
+
 
 async def test_handle_header_fallback():
     """Test _handle_header fallback paths."""

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b3"
+version = "5.0.3b4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-21T11:19:36.301695302Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b0"
+version = "5.0.3b1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b4"
+version = "5.0.3b5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b2"
+version = "5.0.3b3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-17T14:26:30.615881642Z"
+exclude-newer = "2026-06-21T11:19:36.301695302Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.2"
+version = "5.0.3b0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-22T09:36:33.114483706Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b5"
+version = "5.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "s0pcm-reader"
-version = "5.0.3b1"
+version = "5.0.3b2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
Automated stable release PR for version 5.0.3.

### Changes in this release:
- Release v5.0.3 (#329)
- Release v5.0.3-b4 (#328)
- Release v5.0.3-b2 (#325)
- Release v5.0.3-b2 (#324)
- Release v5.0.3-b0 (#323)

### Changelog entries:
```markdown
### Added
- **CI/CD**: Integrated `zizmor` static analysis linter to audit GitHub Actions workflows for security vulnerabilities and best practices locally and on push/pull requests.

### Changed
- **CI/CD**: Hardened all GitHub Actions workflows against template injection, credential persistence, and excessive secret access.
- **Dependencies**: Dependency updates.

### Fixed
- **Serial Connection**: Fixed an issue where only the first pulse counter (counter 1) reset/rolled over at 00:00. Now, all pulse counters correctly reset to 0 and roll over to yesterday's counts when the day changes (closes #327).
```
